### PR TITLE
Reimplement getContractData using getLedgerEntry

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -105,20 +105,23 @@ export class Server {
    *
    * Allows you to directly inspect the current state of a contract. This is a backup way to access your contract data which may not be available via events or simulateTransaction.
    *
-   * @deprecated Use {@link Server#getLedgerEntry} instead.
    * @param {string} contractId - The contract ID containing the data to load. Encoded as a hex string.
    * @param {xdr.ScVal} key - The key of the contract data to load.
-   * @returns {Promise<SorobanRpc.GetContractDataResponse>} Returns a promise to the {@link SorobanRpc.GetContractDataResponse} object with the current value.
+   * @returns {Promise<SorobanRpc.GetLedgerEntryResponse>} Returns a promise to the {@link SorobanRpc.GetLedgerEntryResponse} object with the current value.
    */
   public async getContractData(
     contractId: string,
     key: xdr.ScVal,
-  ): Promise<SorobanRpc.GetContractDataResponse> {
+  ): Promise<SorobanRpc.GetLedgerEntryResponse> {
     return await jsonrpc.post(
       this.serverURL.toString(),
-      "getContractData",
-      contractId,
-      key.toXDR("base64"),
+      "getLedgerEntry",
+      xdr.LedgerKey.contractData(
+        new xdr.LedgerKeyContractData({
+          contractId: Buffer.from(contractId, "hex"),
+          key,
+        }),
+      ).toXDR("base64"),
     );
   }
 

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -39,15 +39,6 @@ export namespace SorobanRpc {
     status: "healthy";
   }
 
-  /* Response for jsonrpc method `getContractData`
-   */
-  export interface GetContractDataResponse {
-    // xdr is a base-64 encoded {@link xdr.ScVal}
-    xdr: string;
-    lastModifiedLedgerSeq?: number;
-    latestLedger?: number;
-  }
-
   /* Response for jsonrpc method `getLedgerEntry`
    */
   export interface GetLedgerEntryResponse {

--- a/test/unit/server/get_contract_data_test.js
+++ b/test/unit/server/get_contract_data_test.js
@@ -1,4 +1,5 @@
 const MockAdapter = require('axios-mock-adapter');
+let xdr = SorobanClient.xdr;
 
 describe('Server#getContractData', function() {
   beforeEach(function() {
@@ -31,8 +32,15 @@ describe('Server#getContractData', function() {
         {
           jsonrpc: '2.0',
           id: 1,
-          method: 'getContractData',
-          params: [address, key.toXDR('base64')]
+          method: 'getLedgerEntry',
+          params: [
+            xdr.LedgerKey.contractData(
+              new xdr.LedgerKeyContractData({
+                contractId: Buffer.from(address, "hex"),
+                key,
+              })
+            ).toXDR("base64")
+          ]
         }
       )
       .returns(Promise.resolve({ data: { result } }));
@@ -56,8 +64,15 @@ describe('Server#getContractData', function() {
         {
           jsonrpc: '2.0',
           id: 1,
-          method: 'getContractData',
-          params: [address, key.toXDR('base64')]
+          method: 'getLedgerEntry',
+          params: [
+            xdr.LedgerKey.contractData(
+              new xdr.LedgerKeyContractData({
+                contractId: Buffer.from(address, "hex"),
+                key,
+              })
+            ).toXDR("base64")
+          ]
         }
       )
       .returns(Promise.resolve({ data: { error: { code: 404 } } }));


### PR DESCRIPTION
Since getLedgerEntry in soroban-rpc is deprecated. Stop using it. But, the method is useful for clients, so instead, we can do the same functionality in the client directly by just building the ledger entry key to lookup.

Part of https://github.com/stellar/soroban-tools/issues/316