### PR TITLE
Reimplement getAccount using getLedgerEntry

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@
 
 import isEmpty from "lodash/isEmpty";
 import merge from "lodash/merge";
-import { FeeBumpTransaction, Transaction, xdr } from "stellar-base";
+import { Account, FeeBumpTransaction, StrKey, Transaction, xdr } from "stellar-base";
 import URI from "urijs";
 
 import * as jsonrpc from "./jsonrpc";
@@ -66,12 +66,26 @@ export class Server {
    * });
    *
    * @param {string} address - The public address of the account to load.
-   * @returns {Promise<SorobanRpc.GetAccountResponse>} Returns a promise to the {@link SorobanRpc.GetAccountResponse} object with populated sequence number.
+   * @returns {Promise<Account>} Returns a promise to the {@link Account} object with populated sequence number.
    */
   public async getAccount(
     address: string,
-  ): Promise<SorobanRpc.GetAccountResponse> {
-    return await jsonrpc.post(this.serverURL.toString(), "getAccount", address);
+  ): Promise<Account> {
+    const { xdr: ledgerEntryData } = await jsonrpc.post(
+      this.serverURL.toString(),
+      "getLedgerEntry",
+      xdr.LedgerKey.account(
+        new xdr.LedgerKeyAccount({
+          accountId: xdr.PublicKey.publicKeyTypeEd25519(
+            StrKey.decodeEd25519PublicKey(address),
+          ),
+        }),
+      ).toXDR("base64")
+    );
+    const accountEntry = xdr.LedgerEntryData.fromXDR(ledgerEntryData, "base64").account();
+    const {high, low} = accountEntry.seqNum();
+    const sequence = (BigInt(high) * BigInt(4294967296)) + BigInt(low);
+    return new Account(address, sequence.toString());
   }
 
   /**

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -26,15 +26,6 @@ export namespace SorobanRpc {
 
   export type TransactionStatus = "pending" | "success" | "error";
 
-  /* Response for jsonrpc method `getAccount`
-   * @interface SorobanRpc.GetAccountResponse
-   */
-  export interface GetAccountResponse {
-    id: string;
-    sequence: string;
-    balances: Balance[];
-  }
-
   export interface GetHealthResponse {
     status: "healthy";
   }

--- a/test/unit/server/get_account_test.js
+++ b/test/unit/server/get_account_test.js
@@ -1,6 +1,8 @@
 const MockAdapter = require('axios-mock-adapter');
 
 describe('Server#getAccount', function() {
+  const { Account, StrKey, xdr } = SorobanClient;
+
   beforeEach(function() {
     this.server = new SorobanClient.Server(serverUrl);
     this.axiosMock = sinon.mock(AxiosClient);
@@ -12,11 +14,10 @@ describe('Server#getAccount', function() {
   });
 
   it('requests the correct method', function(done) {
-    let address = 'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K';
-    let result = {
-      id: address,
-      sequence: "1",
-    };
+    const address = 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI';
+    const accountId = xdr.PublicKey.publicKeyTypeEd25519(
+      StrKey.decodeEd25519PublicKey(address),
+    );
 
     this.axiosMock
       .expects('post')
@@ -25,16 +26,23 @@ describe('Server#getAccount', function() {
         {
           jsonrpc: '2.0',
           id: 1,
-          method: 'getAccount',
-          params: [address],
+          method: 'getLedgerEntry',
+          params: [xdr.LedgerKey.account(
+            new xdr.LedgerKeyAccount({
+              accountId,
+            }),
+          ).toXDR("base64")],
         }
       )
-      .returns(Promise.resolve({ data: { result } }));
+      .returns(Promise.resolve({ data: { result: {
+        xdr: "AAAAAAAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1g3gtpoE608YAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAQAAAAAY9D8iA",
+      }} }));
 
+    const expected = new Account(address, "1");
     this.server
       .getAccount(address)
       .then(function(response) {
-        expect(response).to.be.deep.equal(result);
+        expect(response).to.be.deep.equal(expected);
         done();
       })
       .catch(function(err) {


### PR DESCRIPTION
Part of https://github.com/stellar/go/issues/4716

Turns out we can implement getAccount in the client just using the `getLedgerEntry` endpoint of soroban-rpc.

This also changes the return type to an `Account` to be easier to use with txn building, matching https://github.com/stellar/js-soroban-client/pull/41