### PR TITLE
Add `server.prepareTransaction`

### DIFF
--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -42,14 +42,14 @@ const server = new SorobanClient.Server('http://localhost:8000/soroban/rpc');
 (async function main() {
   // Transactions require a valid sequence number that is specific to this account.
   // We can fetch the current sequence number for the source account from Horizon.
-  const account = await server.loadAccount(sourcePublicKey);
+  const account = await server.getAccount(sourcePublicKey);
 
   // Right now, this is just the default fee for this example.
   const fee = 100;
 
   const contract = new SorobanClient.Contract(contractId);
 
-  const transaction = new SorobanClient.TransactionBuilder(account, {
+  let transaction = new SorobanClient.TransactionBuilder(account, {
       fee,
       // Uncomment the following line to build transactions for the live network. Be
       // sure to also change the soroban-rpc hostname.
@@ -63,6 +63,11 @@ const server = new SorobanClient.Server('http://localhost:8000/soroban/rpc');
     // Uncomment to add a memo (https://developers.stellar.org/docs/glossary/transactions/)
     // .addMemo(SorobanClient.Memo.text('Hello world!'))
     .build();
+
+  // Simulate the transaction to discover the storage footprint, and update the
+  // transaction to include it. If you already know the storage footprint you
+  // can use `addFootprint` to add it yourself, skipping this step.
+  transaction = await server.prepareTransaction(transaction);
 
   // Sign this transaction with the secret key
   // NOTE: signing is transaction is network specific. Test network transactions

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -68,13 +68,18 @@ const server = new SorobanClient.Server('http://localhost:8000/soroban/rpc');
 
     const contract = new SorobanClient.Contract(contractId);
 
-    const transaction = new SorobanClient.TransactionBuilder(account, { fee, networkPassphrase: SorobanClient.Networks.TESTNET })
+    let transaction = new SorobanClient.TransactionBuilder(account, { fee, networkPassphrase: SorobanClient.Networks.TESTNET })
         .addOperation(
             // An operation to call increment on the contract
             contract.call("increment")
         )
         .setTimeout(30)
         .build();
+
+    // Simulate the transaction to discover the storage footprint, and update the
+    // transaction to include it. If you already know the storage footprint you
+    // can use `addFootprint` to add it yourself, skipping this step.
+    transaction = await server.prepareTransaction(transaction);
 
     // sign the transaction
     transaction.sign(SorobanClient.Keypair.fromSecret(secretString));

--- a/src/footprint.ts
+++ b/src/footprint.ts
@@ -1,0 +1,39 @@
+import { Account, FeeBumpTransaction, Operation, Transaction, TransactionBuilder, xdr } from "stellar-base";
+
+// TODO: Transaction is immutable, so we need to re-build it here. :(
+export function addFootprint(raw: Transaction | FeeBumpTransaction, networkPassphrase: string, footprint: Buffer | string | xdr.LedgerFootprint): Transaction {
+  if (!(footprint instanceof xdr.LedgerFootprint)) {
+    footprint = xdr.LedgerFootprint.fromXDR(footprint.toString(), 'base64');
+  }
+  if ('innerTransaction' in raw) {
+    // TODO: Handle feebump transactions
+    return addFootprint(raw.innerTransaction, networkPassphrase, footprint);
+  }
+  // TODO: Figure out a cleaner way to clone this transaction.
+  const source = new Account(raw.source, `${parseInt(raw.sequence)-1}`);
+  const txn = new TransactionBuilder(source, {
+    fee: raw.fee,
+    memo: raw.memo,
+    networkPassphrase,
+    timebounds: raw.timeBounds,
+    ledgerbounds: raw.ledgerBounds,
+    minAccountSequence: raw.minAccountSequence,
+    minAccountSequenceAge: raw.minAccountSequenceAge,
+    minAccountSequenceLedgerGap: raw.minAccountSequenceLedgerGap,
+    extraSigners: raw.extraSigners,
+  });
+  for (let rawOp of raw.operations) {
+    if ('function' in rawOp) {
+      // TODO: Figure out a cleaner way to clone these operations
+      txn.addOperation(Operation.invokeHostFunction({
+        function: rawOp.function,
+        parameters: rawOp.parameters,
+        footprint,
+      }));
+    } else {
+      // TODO: Handle this.
+      throw new Error("Unsupported operation type");
+    }
+  }
+  return txn.build();
+}

--- a/src/footprint.ts
+++ b/src/footprint.ts
@@ -3,14 +3,14 @@ import { Account, FeeBumpTransaction, Operation, Transaction, TransactionBuilder
 // TODO: Transaction is immutable, so we need to re-build it here. :(
 export function addFootprint(raw: Transaction | FeeBumpTransaction, networkPassphrase: string, footprint: Buffer | string | xdr.LedgerFootprint): Transaction {
   if (!(footprint instanceof xdr.LedgerFootprint)) {
-    footprint = xdr.LedgerFootprint.fromXDR(footprint.toString(), 'base64');
+    footprint = xdr.LedgerFootprint.fromXDR(footprint.toString(), "base64");
   }
-  if ('innerTransaction' in raw) {
+  if ("innerTransaction" in raw) {
     // TODO: Handle feebump transactions
     return addFootprint(raw.innerTransaction, networkPassphrase, footprint);
   }
   // TODO: Figure out a cleaner way to clone this transaction.
-  const source = new Account(raw.source, `${parseInt(raw.sequence)-1}`);
+  const source = new Account(raw.source, `${parseInt(raw.sequence, 10) - 1}`);
   const txn = new TransactionBuilder(source, {
     fee: raw.fee,
     memo: raw.memo,
@@ -22,8 +22,8 @@ export function addFootprint(raw: Transaction | FeeBumpTransaction, networkPassp
     minAccountSequenceLedgerGap: raw.minAccountSequenceLedgerGap,
     extraSigners: raw.extraSigners,
   });
-  for (let rawOp of raw.operations) {
-    if ('function' in rawOp) {
+  for (const rawOp of raw.operations) {
+    if ("function" in rawOp) {
       // TODO: Figure out a cleaner way to clone these operations
       txn.addOperation(Operation.invokeHostFunction({
         function: rawOp.function,

--- a/src/server.ts
+++ b/src/server.ts
@@ -391,9 +391,12 @@ export class Server {
    */
   public async prepareTransaction(
     transaction: Transaction | FeeBumpTransaction,
+    networkPassphrase?: string,
   ): Promise<Transaction | FeeBumpTransaction> {
     let [{ passphrase }, { footprint }] = await Promise.all([
-      this.getNetwork(),
+      networkPassphrase
+        ? Promise.resolve({ passphrase: networkPassphrase })
+        : this.getNetwork(),
       this.simulateTransaction(transaction),
     ])
     return addFootprint(transaction, passphrase, footprint);

--- a/src/server.ts
+++ b/src/server.ts
@@ -274,7 +274,11 @@ export class Server {
    * Fetches metadata about the network which Soroban-RPC is connected to.
    *
    * @example
-   * server.getNetwork();
+   * server.getNetwork().then(network => {
+   *   console.log("friendbotUrl:", network.friendbotUrl);
+   *   console.log("passphrase:", network.passphrase);
+   *   console.log("protocolVersion:", network.protocolVersion);
+   * });
    *
    * @returns {Promise<SorobanRpc.GetNetworkResponse>} a promise to the
    *    {@link SorobanRpc.GetNetworkResponse} object containing metadata
@@ -386,6 +390,9 @@ export class Server {
    * @param {Transaction | FeeBumpTransaction} transaction - The transaction to
    *    prepare. It should include exactly one operation, which must be a
    *    {@link InvokeHostFunctionOp}. Any provided footprint will be overwritten.
+   * @param {string} [networkPassphrase] - Explicitly provide a network
+   *    passphrase. If not passed, the current network passphrase will be requested
+   *    from the server via `getNetwork`.
    * @returns {Promise<Transaction | FeeBumpTransaction>} Returns a copy of the
    *    transaction, with the expected ledger footprint added.
    */

--- a/src/server.ts
+++ b/src/server.ts
@@ -393,12 +393,12 @@ export class Server {
     transaction: Transaction | FeeBumpTransaction,
     networkPassphrase?: string,
   ): Promise<Transaction | FeeBumpTransaction> {
-    let [{ passphrase }, { footprint }] = await Promise.all([
+    const [{ passphrase }, { footprint }] = await Promise.all([
       networkPassphrase
         ? Promise.resolve({ passphrase: networkPassphrase })
         : this.getNetwork(),
       this.simulateTransaction(transaction),
-    ])
+    ]);
     return addFootprint(transaction, passphrase, footprint);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,11 +5,10 @@ import merge from "lodash/merge";
 import { Account, FeeBumpTransaction, StrKey, Transaction, xdr } from "stellar-base";
 import URI from "urijs";
 
-import * as jsonrpc from "./jsonrpc";
-
-import { SorobanRpc } from "./soroban_rpc";
-
 import AxiosClient from "./axios";
+import { addFootprint } from "./footprint";
+import * as jsonrpc from "./jsonrpc";
+import { SorobanRpc } from "./soroban_rpc";
 
 export const SUBMIT_TRANSACTION_TIMEOUT = 60 * 1000;
 
@@ -341,6 +340,63 @@ export class Server {
       "simulateTransaction",
       transaction.toXDR(),
     );
+  }
+
+  /**
+   * Submit a trial contract invocation, then add the expected
+   * ledger footprint into the transaction so it is ready for signing & sending.
+   *
+   * @example
+   * const contractId = '0000000000000000000000000000000000000000000000000000000000000001';
+   * const contract = new SorobanClient.Contract(contractId);
+   *
+   * // Right now, this is just the default fee for this example.
+   * const fee = 100;
+   *
+   * const transaction = new SorobanClient.TransactionBuilder(account, {
+   *     fee,
+   *     // Uncomment the following line to build transactions for the live network. Be
+   *     // sure to also change the horizon hostname.
+   *     // networkPassphrase: SorobanClient.Networks.PUBLIC,
+   *     networkPassphrase: SorobanClient.Networks.TESTNET
+   *   })
+   *   // Add a contract.increment soroban contract invocation operation
+   *   .addOperation(contract.call("increment"))
+   *   // Make this transaction valid for the next 30 seconds only
+   *   .setTimeout(30)
+   *   // Uncomment to add a memo (https://developers.stellar.org/docs/glossary/transactions/)
+   *   // .addMemo(SorobanClient.Memo.text('Hello world!'))
+   *   .build();
+   *
+   * preparedTransaction = await server.prepareTransaction(transaction);
+   *
+   * // Sign this transaction with the secret key
+   * // NOTE: signing is transaction is network specific. Test network transactions
+   * // won't work in the public network. To switch networks, use the Network object
+   * // as explained above (look for SorobanClient.Network).
+   * const sourceKeypair = SorobanClient.Keypair.fromSecret(sourceSecretKey);
+   * preparedTransaction.sign(sourceKeypair);
+   *
+   * server.sendTransaction(transaction).then(result => {
+   *   console.log("id:", result.id);
+   *   console.log("status:", result.status);
+   *   console.log("error:", result.error);
+   * });
+   *
+   * @param {Transaction | FeeBumpTransaction} transaction - The transaction to
+   *    prepare. It should include exactly one operation, which must be a
+   *    {@link InvokeHostFunctionOp}. Any provided footprint will be overwritten.
+   * @returns {Promise<Transaction | FeeBumpTransaction>} Returns a copy of the
+   *    transaction, with the expected ledger footprint added.
+   */
+  public async prepareTransaction(
+    transaction: Transaction | FeeBumpTransaction,
+  ): Promise<Transaction | FeeBumpTransaction> {
+    let [{ passphrase }, { footprint }] = await Promise.all([
+      this.getNetwork(),
+      this.simulateTransaction(transaction),
+    ])
+    return addFootprint(transaction, passphrase, footprint);
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@
 
 import isEmpty from "lodash/isEmpty";
 import merge from "lodash/merge";
-import { FeeBumpTransaction, Transaction, xdr } from "stellar-base";
+import { Account, FeeBumpTransaction, StrKey, Transaction, xdr } from "stellar-base";
 import URI from "urijs";
 
 import * as jsonrpc from "./jsonrpc";
@@ -66,12 +66,26 @@ export class Server {
    * });
    *
    * @param {string} address - The public address of the account to load.
-   * @returns {Promise<SorobanRpc.GetAccountResponse>} Returns a promise to the {@link SorobanRpc.GetAccountResponse} object with populated sequence number.
+   * @returns {Promise<Account>} Returns a promise to the {@link Account} object with populated sequence number.
    */
   public async getAccount(
     address: string,
-  ): Promise<SorobanRpc.GetAccountResponse> {
-    return await jsonrpc.post(this.serverURL.toString(), "getAccount", address);
+  ): Promise<Account> {
+    const { xdr: ledgerEntryData } = await jsonrpc.post(
+      this.serverURL.toString(),
+      "getLedgerEntry",
+      xdr.LedgerKey.account(
+        new xdr.LedgerKeyAccount({
+          accountId: xdr.PublicKey.publicKeyTypeEd25519(
+            StrKey.decodeEd25519PublicKey(address),
+          ),
+        }),
+      ).toXDR("base64")
+    );
+    const accountEntry = xdr.LedgerEntryData.fromXDR(ledgerEntryData, "base64").account();
+    const {high, low} = accountEntry.seqNum();
+    const sequence = (BigInt(high) * BigInt(4294967296)) + BigInt(low);
+    return new Account(address, sequence.toString());
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -272,6 +272,20 @@ export class Server {
   }
 
   /**
+   * Fetches metadata about the network which Soroban-RPC is connected to.
+   *
+   * @example
+   * server.getNetwork();
+   *
+   * @returns {Promise<SorobanRpc.GetNetworkResponse>} a promise to the
+   *    {@link SorobanRpc.GetNetworkResponse} object containing metadata
+   *    about the current network this soroban-rpc server is connected to.
+   */
+  public async getNetwork(): Promise<SorobanRpc.GetNetworkResponse> {
+    return await jsonrpc.post(this.serverURL.toString(), "getNetwork");
+  }
+
+  /**
    * Submit a trial contract invocation to get back return values, expected
    * ledger footprint, and expected costs.
    *

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -50,7 +50,6 @@ export namespace SorobanRpc {
     protocolVersion: string;
   }
 
-
   export interface GetTransactionStatusResponse {
     id: string;
     status: TransactionStatus;

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -26,15 +26,6 @@ export namespace SorobanRpc {
 
   export type TransactionStatus = "pending" | "success" | "error";
 
-  /* Response for jsonrpc method `getAccount`
-   * @interface SorobanRpc.GetAccountResponse
-   */
-  export interface GetAccountResponse {
-    id: string;
-    sequence: string;
-    balances: Balance[];
-  }
-
   export interface GetHealthResponse {
     status: "healthy";
   }

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -39,6 +39,18 @@ export namespace SorobanRpc {
     latestLedger?: number;
   }
 
+  /* Response for jsonrpc method `getNetwork`
+   */
+  export interface GetNetworkResponse {
+    friendbotUrl?: string;
+    latestLedgerHash: string;
+    latestLedgerSeq: number;
+    latestLedgerTime: string;
+    passphrase: string;
+    protocolVersion: string;
+  }
+
+
   export interface GetTransactionStatusResponse {
     id: string;
     status: TransactionStatus;

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -43,9 +43,6 @@ export namespace SorobanRpc {
    */
   export interface GetNetworkResponse {
     friendbotUrl?: string;
-    latestLedgerHash: string;
-    latestLedgerSeq: number;
-    latestLedgerTime: string;
     passphrase: string;
     protocolVersion: string;
   }

--- a/test/unit/server/get_account_test.js
+++ b/test/unit/server/get_account_test.js
@@ -1,6 +1,8 @@
 const MockAdapter = require('axios-mock-adapter');
 
 describe('Server#getAccount', function() {
+  const { Account, StrKey, xdr } = SorobanClient;
+
   beforeEach(function() {
     this.server = new SorobanClient.Server(serverUrl);
     this.axiosMock = sinon.mock(AxiosClient);
@@ -12,11 +14,10 @@ describe('Server#getAccount', function() {
   });
 
   it('requests the correct method', function(done) {
-    let address = 'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K';
-    let result = {
-      id: address,
-      sequence: "1",
-    };
+    const address = 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI';
+    const accountId = xdr.PublicKey.publicKeyTypeEd25519(
+      StrKey.decodeEd25519PublicKey(address),
+    );
 
     this.axiosMock
       .expects('post')
@@ -25,16 +26,23 @@ describe('Server#getAccount', function() {
         {
           jsonrpc: '2.0',
           id: 1,
-          method: 'getAccount',
-          params: [address],
+          method: 'getLedgerEntry',
+          params: [xdr.LedgerKey.account(
+            new xdr.LedgerKeyAccount({
+              accountId,
+            }),
+          ).toXDR("base64")],
         }
       )
-      .returns(Promise.resolve({ data: { result } }));
+      .returns(Promise.resolve({ data: { result: {
+        xdr: "AAAAAAAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1g3gtpoE608YAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAQAAAAAY9D8iA",
+      }} }));
 
+    const expected = new Account(address, "1");
     this.server
       .getAccount(address)
       .then(function(response) {
-        expect(response).to.be.deep.equal(result);
+        expect(response).to.be.deep.equal(expected);
         done();
       })
       .catch(function(err) {


### PR DESCRIPTION
Adds a `server.prepareTransaction` method, which calls `simulateTransaction` then adds the resulting footprint into the transaction.

Depends on https://github.com/stellar/soroban-tools/pull/366

Fixes https://github.com/stellar/js-soroban-client/issues/39