### PR TITLE
add server method for rpc getLatestLedger endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -296,6 +296,24 @@ export class Server {
   }
 
   /**
+   * Fetches the latest ledger meta info from network which Soroban-RPC is connected to.
+   *
+   * @example
+   * server.getLatestLedger().then(response => {
+   *   console.log("hash:", response.id);
+   *   console.log("sequence:", response.sequence);
+   *   console.log("protocolVersion:", response.protocolVersion);
+   * });
+   *
+   * @returns {Promise<SorobanRpc.GetLatestLedgerResponse>} a promise to the
+   *    {@link SorobanRpc.GetLatestLedgerResponse} object containing metadata
+   *    about the latest ledger from network soroban-rpc server is connected to.
+   */
+  public async getLatestLedger(): Promise<SorobanRpc.GetLatestLedgerResponse> {
+    return await jsonrpc.post(this.serverURL.toString(), "getLatestLedger");
+  }
+
+  /**
    * Submit a trial contract invocation to get back return values, expected
    * ledger footprint, expected authorizations, and expected costs.
    *

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -41,7 +41,7 @@ export namespace SorobanRpc {
     protocolVersion: string;
   }
 
-  /* Response for jsonrpc method `getNetwork`
+  /* Response for jsonrpc method `getLatestLedger`
    */
   export interface GetLatestLedgerResponse {
     id: string;

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -41,6 +41,14 @@ export namespace SorobanRpc {
     protocolVersion: string;
   }
 
+  /* Response for jsonrpc method `getNetwork`
+   */
+  export interface GetLatestLedgerResponse {
+    id: string;
+    sequence: number;
+    protocolVersion: string;
+  }
+
   export type GetTransactionStatus = "SUCCESS" | "NOT_FOUND" | "FAILED";
 
   export interface GetTransactionResponse {

--- a/test/unit/server/get_latest_ledger_test.js
+++ b/test/unit/server/get_latest_ledger_test.js
@@ -1,0 +1,40 @@
+const MockAdapter = require("axios-mock-adapter");
+
+describe("Server#getLatestLedger", function() {
+  beforeEach(function() {
+    this.server = new SorobanClient.Server(serverUrl);
+    this.axiosMock = sinon.mock(AxiosClient);
+  });
+
+  afterEach(function() {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+  it("requests the correct method", function(done) {
+    const result = {
+      id: "hashed_id",
+      sequence: 123,
+      protocolVersion: 20,
+    };
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLatestLedger",
+        params: [],
+      })
+      .returns(Promise.resolve({ data: { result } }));
+
+    this.server
+      .getLatestLedger()
+      .then(function(response) {
+        expect(response).to.be.deep.equal(result);
+        done();
+      })
+      .catch(function(err) {
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
Added new server method to wrap the rpc `getLatestLedger` endpoint.

Need access to this endpoint to obtain recent ledger number for polling contract events in a related dapp story - https://github.com/stellar/soroban-tools/issues/458