### PR TITLE
remove params from jsonrpc post payload if empty

### DIFF
--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -35,6 +35,9 @@ export async function post<T>(
   method: string,
   ...params: any
 ): Promise<T> {
+  if (params && params.length < 1) {
+    params = null;
+  }
   const response = await axios.post<Response<T>>(url, {
     jsonrpc: "2.0",
     // TODO: Generate a unique request id

--- a/test/unit/server/get_health_test.js
+++ b/test/unit/server/get_health_test.js
@@ -22,7 +22,7 @@ describe("Server#getHealth", function() {
         jsonrpc: "2.0",
         id: 1,
         method: "getHealth",
-        params: [],
+        params: null,
       })
       .returns(Promise.resolve({ data: { result } }));
 

--- a/test/unit/server/get_latest_ledger_test.js
+++ b/test/unit/server/get_latest_ledger_test.js
@@ -23,7 +23,7 @@ describe("Server#getLatestLedger", function() {
         jsonrpc: "2.0",
         id: 1,
         method: "getLatestLedger",
-        params: [],
+        params: null,
       })
       .returns(Promise.resolve({ data: { result } }));
 

--- a/test/unit/server/get_network_test.js
+++ b/test/unit/server/get_network_test.js
@@ -23,7 +23,7 @@ describe("Server#getNetwork", function() {
         jsonrpc: "2.0",
         id: 1,
         method: "getNetwork",
-        params: [],
+        params: null,
       })
       .returns(Promise.resolve({ data: { result } }));
 

--- a/test/unit/server/request_airdrop_test.js
+++ b/test/unit/server/request_airdrop_test.js
@@ -63,7 +63,7 @@ describe("Server#requestAirdrop", function() {
         jsonrpc: "2.0",
         id: 1,
         method: "getNetwork",
-        params: [],
+        params: null,
       })
       .returns(Promise.resolve({ data: { result } }));
   }


### PR DESCRIPTION
when the jsonrpc.post() method:

```
export async function post<T>(
  url: string,
  method: string,
  ...params: any
)
```


 is webpacked for browser usage, there's some additional polyfill added to handle the spread `params` :

```
function post(url, method) {
    var _a;
    var params = [];
    for (var _i = 2; _i < arguments.length; _i++) {
        params[_i - 2] = arguments[_i];
    }

```

however, for methods such as getNetwork, getHealth, getLatestLedger that pass no `params` the result would still include `params: []` in the json rpc post, which rpc server rejects with err:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32602,
        "message": "no parameters accepted"
    }
}

```

https://github.com/stellar/soroban-tools/issues/458 will depend on this, it uses `getLatestLedger`