### PR TITLE
Update completed sprint on issue closed

### DIFF
--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [closed]
   pull_request:
-    types: [closed, comment]
+    types: [closed]
 
 jobs:
   update-completed-sprint:


### PR DESCRIPTION
Use https://github.com/stellar/actions/pull/52, to automatically set the CompletedSprint field on issues/PRs in the Platform Scrum project when they are closed.