### PR TITLE
fix: move type libs to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,11 @@
     "@stellar/tsconfig": "^1.0.1",
     "@stellar/tslint-config": "^1.0.3",
     "@types/detect-node": "^2.0.0",
+    "@types/eventsource": "^1.1.2",
     "@types/lodash": "4.14.186",
+    "@types/node": "18.11.9",
+    "@types/randombytes": "^2.0.0",
+    "@types/urijs": "^1.19.6",
     "axios-mock-adapter": "^1.16.0",
     "babel-cli": "^6.26.0",
     "babel-core": "~6.26.3",
@@ -131,10 +135,6 @@
     "webpack-stream": "^5.2.1"
   },
   "dependencies": {
-    "@types/eventsource": "^1.1.2",
-    "@types/node": "18.11.9",
-    "@types/randombytes": "^2.0.0",
-    "@types/urijs": "^1.19.6",
     "axios": "0.25.0",
     "es6-promise": "^4.2.4",
     "lodash": "4.17.21",


### PR DESCRIPTION
This PR moves the type libraries to devDependencies, as they are only needed for development and not for production.