### PR TITLE
removed reference to gulp in js docs build

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: stellar/js-stellar-base
+          ref: soroban
           path: js-stellar-base
 
       - name: Install Node (14.x)
@@ -25,9 +26,6 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install
-
-      - name: Build
-        run: gulp
 
       - name: Checkout GH pages
         uses: actions/checkout@v3

--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,6 +1,6 @@
 {
   "source": {
-    "include": ["libdocs", "js-stellar-base/src"],
+    "include": ["lib", "js-stellar-base/src"],
     "exclude": "js-stellar-base/src/generated"
   },
   "opts": {


### PR DESCRIPTION
fix gh ci step for building and publishing jsdocs on a release, it was referring older gulp, which is no longer needed:

https://github.com/stellar/js-soroban-client/actions/runs/5017799282/jobs/8996387167