### PR TITLE
include ts.d files in output lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "cross-env NODE_ENV=development yarn _build",
     "build:prod": "cross-env NODE_ENV=production yarn _build",
-    "build:node": "babel --extensions '.ts' --out-dir lib/ src/",
+    "build:ts": "npx tsc",
+    "build:node": "yarn build:ts && babel --extensions '.ts' --out-dir lib/ src/",
     "build:browser": "webpack -c ./webpack.config.browser.js",
     "clean": "rm -rf lib/ dist/ coverage/ .nyc_output/",
     "docs": "jsdoc -c ./.jsdoc.json --verbose",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=development yarn _build",
     "build:prod": "cross-env NODE_ENV=production yarn _build",
-    "build:ts": "npx tsc",
+    "build:ts": "yarn run tsc",
     "build:node": "yarn build:ts && babel --extensions '.ts' --out-dir lib/ src/",
     "build:browser": "webpack -c ./webpack.config.browser.js",
     "clean": "rm -rf lib/ dist/ coverage/ .nyc_output/",

--- a/src/server.ts
+++ b/src/server.ts
@@ -82,7 +82,7 @@ export class Server {
    * @returns {Promise<Account>} Returns a promise to the {@link Account} object with populated sequence number.
    */
   public async getAccount(address: string): Promise<Account> {
-    const { xdr: ledgerEntryData } = await jsonrpc.post(
+    const { xdr: ledgerEntryData } = await jsonrpc.post<SorobanRpc.GetLedgerEntryResponse>(
       this.serverURL.toString(),
       "getLedgerEntry",
       xdr.LedgerKey.account(
@@ -553,7 +553,7 @@ export class Server {
       );
       const sequence = findCreatedAccountSequenceInTransactionMeta(meta);
       return new Account(account, sequence);
-    } catch (error) {
+    } catch (error: any) {
       if (error.response?.status === 400) {
         if (error.response.detail?.includes("createAccountAlreadyExist")) {
           // Account already exists, load the sequence number

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@stellar/tsconfig",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "declarationDir": "lib",
     "lib": ["es2015"],
     "moduleResolution": "node",


### PR DESCRIPTION
the *.ts.d files were not being included in the lib output, causing ts validation errors for downstream client usage of types. 

Closes #81 