### PR TITLE
Keep jsdoc comments in published *.d.ts files.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationDir": "lib",
+    "removeComments": false,
     "lib": ["es2015"],
     "moduleResolution": "node",
     "rootDir": "src",


### PR DESCRIPTION
The `lib/*.d.ts` files will now keep the jsdocs so that developers can see docs without relying on the [external site](https://stellar.github.io/js-soroban-client/).