### PR TITLE
Target modern feature sets universally for the published package.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
     ],
     "targets": {
         "node": 14,
-        "browsers": [ "> 2%" ]
+        "browsers": [ "> 2%" ]          // target modern browsers and ES6
     },
     "env": {
         "development": {
@@ -16,15 +16,6 @@
         "docs": {
             "comments": true            // for jsdocs
         },
-        "production": {
-            // stricter target for final browser bundle
-            "targets": {
-                "browsers": [
-                    "> 2%",
-                    "ie 11",
-                    "not op_mini all"
-                ]
-            }
-        }
+        "production": {}
     }
 }


### PR DESCRIPTION
Unlike stellar/js-stellar-sdk, this is a new library with _exclusively_ new adopters. This means that anyone that wants to use the library probably has (or should have) a modern build pipeline. They can transpile to other targets if they'd like, but by default, we want to target the majority of supported features by default.

Additional context [on Slack](https://stellarfoundation.slack.com/archives/C0243P37N3V/p1684869630824169?thread_ts=1684350956.894909&cid=C0243P37N3V).