### PR TITLE
Prepare v0.7.2 for release, further increasing downstream JS compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 
+## v0.7.2
+
+### Fixed
+* Downstream dependencies are transpiled to target the same older JS environments as the main library ([#96](https://github.com/stellar/js-soroban-client/pull/96)).
+
+
 ## v0.7.1
 
 ### Fixed

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,23 +1,18 @@
 {
-    "comments": false,
+    "comments": true, // for debugging & jsdocs
     "presets": [
         "@babel/preset-env",
         "@babel/typescript"
     ],
     "targets": {
-        "node": 14,
         "browsers": [ "> 2%" ]          // target modern browsers and ES6
     },
     "env": {
         "development": {
-            "comments": true,           // for debugging
             "plugins": [ "istanbul" ]   // for code coverage
         },
-        "docs": {
-            "comments": true            // for jsdocs
-        },
         "production": {
-            // stricter target for final browser bundle (more compatibility)
+            "comments": false,
             "targets": {
                 "node": 14,
                 "browsers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soroban-client",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A library for working with Stellar's Soroban RPC servers.",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "homepage": "https://github.com/stellar/js-soroban-client",

--- a/webpack.config.browser.js
+++ b/webpack.config.browser.js
@@ -35,11 +35,11 @@ const config = {
     rules: [
       {
         test: /\.m?(ts|js)$/,
-        exclude: /node_modules/,
+        exclude: /node_modules\/(?!(stellar-base|js-xdr))/,
         use: {
           loader: "babel-loader",
           options: {
-            cacheDirectory: true,
+            cacheDirectory: true
           },
         },
       },


### PR DESCRIPTION
After v0.7.1 (see #95), we broadened compatibility by transpiling browser bundles to an older JS feature set.

Unfortunately, this was insufficient, as Babel ignores any dependencies in Webpack's transpilation step if using a `.babelrc` file. By migrating to a `babel.config.json` file (see [docs here](https://babeljs.io/docs/configuration#whats-your-use-case), "You want to compile `node_modules`?") and adding the appropriate dependencies to the webpack config (note the delta on the `exclude` line), we can transpile these to the same feature set as the library itself.

cc @esteblock if you want to include this in your release, but it isn't required :+1: 