### PR TITLE
Handle null ledger entries and return a better error for missing accounts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -107,11 +107,11 @@ export class Server {
       "getLedgerEntries",
       [ledgerKey],
     );
-    const ledgerEntries = data.entries;
+    const ledgerEntries = data.entries ?? [];
     if (ledgerEntries.length === 0) {
       return Promise.reject({
         code: 404,
-        message: "Ledger entry not found. Key: " + ledgerKey,
+        message: `Account not found: ${address}`,
       });
     }
     const ledgerEntryData = ledgerEntries[0].xdr;
@@ -218,13 +218,14 @@ export class Server {
       "getLedgerEntries",
       [contractKey],
     ).then(response => {
-      if (response.entries.length !== 1) {
+        const ledgerEntries = response.entries ?? [];
+      if (ledgerEntries.length !== 1) {
         return Promise.reject({
           code: 404,
-          message: `Ledger entry not found. Key: ${contractKey}`
+          message: `Contract data not found. Contract: ${Address.fromScAddress(scAddress).toString()}, Key: ${key.toXDR("base64")}, Durability: ${durability}`,
         });
       }
-      return response.entries[0];
+      return ledgerEntries[0];
     });
   }
 
@@ -251,7 +252,7 @@ export class Server {
    *   console.log("latestLedger:", response.latestLedger);
    * });
    *
-   * @param {xdr.ScVal} key - The key of the contract data to load.
+   * @param {xdr.ScVal[]} keys - The ledger entry keys to load.
    *
    * @returns {Promise<SorobanRpc.GetLedgerEntriesResponse>} Returns a promise
    *    to the {@link SorobanRpc.GetLedgerEntriesResponse} object with the

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -34,7 +34,7 @@ export namespace SorobanRpc {
   /* Response for jsonrpc method `getLedgerEntries`
    */
   export interface GetLedgerEntriesResponse {
-    entries: LedgerEntryResult[];
+    entries: LedgerEntryResult[] | null;
     latestLedger: number;
   }
 

--- a/test/unit/server/get_account_test.js
+++ b/test/unit/server/get_account_test.js
@@ -91,7 +91,8 @@ describe("Server#getAccount", function () {
         })
       );
 
-    this.server.getAccount(address)
+    this.server
+      .getAccount(address)
       .then(function (_) {
         done(new Error("Expected error to be thrown"));
       })


### PR DESCRIPTION
This is the js client version of https://github.com/stellar/soroban-tools/pull/771

If the soroban-rpc server finds no matching entries for a `getLedgerEntries`, it will return `entries: null`. The client should handle this.

Also, if we try to do a `getAccount` and don't find it, we can return a more helpful error to the user.