### PR TITLE
Fix bigIntFromBytes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -699,7 +699,7 @@ function bigIntFromBytes(
   ...bytes: Array<number | bigint>
 ): bigint {
   let sign = BigInt(1);
-  if (signed && bytes[0] === 0x80) {
+  if (signed && bytes[0] & 0x80) {
     // top bit is set, negative number.
     sign = BigInt(-1);
     // tslint:disable-next-line:no-bitwise


### PR DESCRIPTION
Line 702 I think is testing the high bit of bytes[0], not the bytes[0] === 0x80
Changed to bytes[0] & 0x80