### PR TITLE
Preserve existing auth entries after simulation if they're present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ A breaking change should be clearly marked in this log.
 ## v0.9.3
 
 ### Fixed
-* `assembleTransaction()` (and `Server.prepareTransaction()` by proxy) will now override the authorization portion of simulation if you provide a transaction with existing authorization entries. This is because, in complex auth scenarios, you may have signed entries that would be overwritten by simulation, so this just uses your existing entries ([#TODO](https://github.com/stellar/js-soroban-client/pull/113)).
+* `assembleTransaction()` (and `Server.prepareTransaction()` by proxy) will now override the authorization portion of simulation if you provide a transaction with existing authorization entries. This is because, in complex auth scenarios, you may have signed entries that would be overwritten by simulation, so this just uses your existing entries ([#114](https://github.com/stellar/js-soroban-client/pull/114)).
 
 
 ## v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 
+## v0.9.3
+
+### Fixed
+* `assembleTransaction()` (and `Server.prepareTransaction()` by proxy) will now override the authorization portion of simulation if you provide a transaction with existing authorization entries. This is because, in complex auth scenarios, you may have signed entries that would be overwritten by simulation, so this just uses your existing entries ([#TODO](https://github.com/stellar/js-soroban-client/pull/113)).
+
+
 ## v0.9.2
 
 ### Updated

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,9 @@ export interface GetEventsRequest {
   limit?: number;
 }
 
+/**
+ * Specifies the durability namespace of contract-related ledger entries.
+ */
 export enum Durability {
   Temporary = 'temporary',
   Persistent = 'persistent',
@@ -523,6 +526,8 @@ export class Server {
    *    invocation) and ledger footprint added. The transaction fee will also
    *    automatically be padded with the contract's minimum resource fees
    *    discovered from the simulation.
+   *
+   * @throws {jsonrpc.Error<any> | Error} if simulation fails
    */
   public async prepareTransaction(
     transaction: Transaction | FeeBumpTransaction,

--- a/src/server.ts
+++ b/src/server.ts
@@ -515,8 +515,13 @@ export class Server {
    * @param {Transaction | FeeBumpTransaction} transaction - The transaction to
    *    prepare. It should include exactly one operation, which must be one of
    *    {@link xdr.InvokeHostFunctionOp}, {@link xdr.BumpFootprintExpirationOp},
-   *    or {@link xdr.RestoreFootprintOp}. Any provided footprint will be
-   *    overwritten.
+   *    or {@link xdr.RestoreFootprintOp}.
+   *
+   *    Any provided footprint will be overwritten. However, if your operation
+   *    has existing auth entries, they will be preferred over ALL auth entries
+   *    from the simulation. In other words, if you include auth entries, you
+   *    don't care about the auth returned from the simulation. Other fields
+   *    (footprint, etc.) will be filled as normal.
    * @param {string} [networkPassphrase] - Explicitly provide a network
    *    passphrase. If not passed, the current network passphrase will be
    *    requested from the server via {@link Server.getNetwork}.

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -66,18 +66,19 @@ export function assembleTransaction(
         Operation.invokeHostFunction({
           source: invokeOp.source,
           func: invokeOp.func,
-          // apply the auth from the simulation
-          auth: (invokeOp.auth ?? []).concat(
-            simulation.results[0].auth?.map((a: string) =>
-              xdr.SorobanAuthorizationEntry.fromXDR(a, "base64")
-            ) ?? []
-          ),
+          // override auth from the simulation: any existing `invokeOp.auth`
+          // should be a subset of what simulation gives us
+          auth: simulation.results[0].auth?.map(
+            (a) => xdr.SorobanAuthorizationEntry.fromXDR(a, "base64")
+          ) ?? []
         })
       );
       break;
 
     case "bumpFootprintExpiration":
-      txnBuilder.addOperation(Operation.bumpFootprintExpiration(raw.operations[0]));
+      txnBuilder.addOperation(
+        Operation.bumpFootprintExpiration(raw.operations[0])
+      );
       break;
 
     case "restoreFootprint":

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -225,8 +225,12 @@ describe("assembleTransaction", () => {
     });
 
     it("doesn't overwrite auth if it's present", function () {
-      const txn = singleContractFnTransaction([ fnAuth, fnAuth, fnAuth ]);
-      const tx = SorobanClient.assembleTransaction(txn, networkPassphrase, simulationResponse);
+      const txn = singleContractFnTransaction([fnAuth, fnAuth, fnAuth]);
+      const tx = SorobanClient.assembleTransaction(
+        txn,
+        networkPassphrase,
+        simulationResponse
+      );
 
       expect(tx.operations[0].auth.length).to.equal(
         3,

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -71,7 +71,7 @@ describe("assembleTransaction", () => {
       "1"
     );
 
-    function singleContractFnTransaction() {
+    function singleContractFnTransaction(auth) {
       return new SorobanClient.TransactionBuilder(source, {
         fee: 100,
         networkPassphrase: "Test",
@@ -80,7 +80,7 @@ describe("assembleTransaction", () => {
         .addOperation(
           SorobanClient.Operation.invokeHostFunction({
             func: new xdr.HostFunction.hostFunctionTypeInvokeContract([]),
-            auth: [],
+            auth: auth ?? [],
           })
         )
         .setTimeout(SorobanClient.TimeoutInfinite)
@@ -222,6 +222,16 @@ describe("assembleTransaction", () => {
         );
         expect(tx.operations[0].type).to.equal(op.body().switch().name);
       });
+    });
+
+    it("doesn't overwrite auth if it's present", function () {
+      const txn = singleContractFnTransaction([ fnAuth, fnAuth, fnAuth ]);
+      const tx = SorobanClient.assembleTransaction(txn, networkPassphrase, simulationResponse);
+
+      expect(tx.operations[0].auth.length).to.equal(
+        3,
+        `auths aren't preserved after simulation: ${simulationResponse}, ${tx}`
+      );
     });
   });
 });


### PR DESCRIPTION
In complex auth scenarios, you may have signed entries that would be overwritten by simulation, so this just uses your existing entries. This should not affect "new" or "fresh" simulations just like before.
