### PR TITLE
Explicitly drops support for hex-encoded contract IDs.

### DIFF
--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -33,7 +33,7 @@ const sourcePublicKey = sourceKeypair.publicKey();
 
 const receiverPublicKey = 'GAIRISXKPLOWZBMFRPU5XRGUUX3VMA3ZEWKBM5MSNRU3CHV6P4PYZ74D';
 
-const contractId = '0000000000000000000000000000000000000000000000000000000000000001';
+const contractId = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
 
 // Configure SorobanClient to talk to the soroban-rpc instance running on your
 // local machine.

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "eventsource": "^2.0.2",
     "lodash": "^4.17.21",
     "randombytes": "^2.1.0",
-    "stellar-base": "10.0.0-soroban.4",
+    "stellar-base": "10.0.0-soroban.5",
     "toml": "^3.0.0",
     "urijs": "^1.19.1"
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -401,7 +401,7 @@ export class Server {
    * ledger footprint, expected authorizations, and expected costs.
    *
    * @example
-   * const contractId = '0000000000000000000000000000000000000000000000000000000000000001';
+   * const contractId = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
    * const contract = new SorobanClient.Contract(contractId);
    *
    * // Right now, this is just the default fee for this example.
@@ -475,7 +475,7 @@ export class Server {
    * first, if that is of importance.
    *
    * @example
-   * const contractId = '0000000000000000000000000000000000000000000000000000000000000001';
+   * const contractId = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
    * const contract = new SorobanClient.Contract(contractId);
    *
    * // Right now, this is just the default fee for this example.
@@ -560,7 +560,7 @@ export class Server {
    * transaction success/failure.
    *
    * @example
-   * const contractId = '0000000000000000000000000000000000000000000000000000000000000001';
+   * const contractId = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
    * const contract = new SorobanClient.Contract(contractId);
    *
    * // Right now, this is just the default fee for this example.
@@ -619,17 +619,22 @@ export class Server {
    * throw an error.  If the request fails, this method will throw an error.
    *
    * @example
-   * server.requestAirdrop("GBZC6Y2Y7Q3ZQ2Y4QZJ2XZ3Z5YXZ6Z7Z2Y4QZJ2XZ3Z5YXZ6Z7Z2Y4").then(accountCreated => {
-   *   console.log("accountCreated:", accountCreated);
-   * }).catch(error => {
-   *   console.error("error:", error);
-   * });
+   * server
+   *    .requestAirdrop("GBZC6Y2Y7Q3ZQ2Y4QZJ2XZ3Z5YXZ6Z7Z2Y4QZJ2XZ3Z5YXZ6Z7Z2Y4")
+   *    .then(accountCreated => {
+   *      console.log("accountCreated:", accountCreated);
+   *    }).catch(error => {
+   *      console.error("error:", error);
+   *    });
    *
-   * @param {string | Account} address - The address or account we want to create and fund.
+   * @param {string | Account} address - The address or account we want to
+   * create and fund.
    * @param {string} [friendbotUrl] - The optional explicit address for
-   *    friendbot. If not provided, the client will call the Soroban-RPC `getNetwork`
-   *    method to attempt to find this network's friendbot url.
-   * @returns {Promise<Account>} Returns a promise to the {@link Account} object with populated sequence number.
+   *    friendbot. If not provided, the client will call the Soroban-RPC
+   *    `getNetwork` method to attempt to find this network's friendbot url.
+   *
+   * @returns {Promise<Account>} Returns a promise to the {@link Account} object
+   *    with populated sequence number.
    */
   public async requestAirdrop(
     address: string | Pick<Account, "accountId">,

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,9 +161,9 @@ export class Server {
    * events or simulateTransaction.
    *
    * @param {string|Address|Contract} contract - The contract ID containing the
-   *    data to load. Encoded as Stellar Contract Address string e.g.
-   *    `CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5` or a
-   *    {@link Contract} or {@link Address} instance.
+   *    data to load. Encoded as Stellar Contract Address string (e.g.
+   *    `CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5`), a
+   *    {@link Contract}, or an {@link Address} instance.
    * @param {xdr.ScVal} key - The key of the contract data to load.
    * @param {Durability} [durability] - The "durability keyspace" that this
    *    ledger key belongs to, which is either 'temporary' or 'persistent' (the
@@ -242,9 +242,9 @@ export class Server {
    * To fetch contract wasm byte-code, use the ContractCode ledger entry key.
    *
    * @example
-   * const contractId = "0000000000000000000000000000000000000000000000000000000000000001";
+   * const contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
    * const key = xdr.LedgerKey.contractData(new xdr.LedgerKeyContractData({
-   *   contractId: Buffer.from(contractId, "hex"),
+   *   contractId: StrKey.decodeContract(contractId),
    *   key: xdr.ScVal.scvSymbol("counter"),
    * }));
    * server.getLedgerEntries([key]).then(response => {
@@ -286,8 +286,7 @@ export class Server {
    *   console.log("resultXdr:", transaction.resultXdr);
    * });
    *
-   * @param {string} hash - The hash of the transaction to check. Encoded as a
-   *    hex string.
+   * @param {string} hash - The hex-encoded hash of the transaction to check.
    *
    * @returns {Promise<SorobanRpc.GetTransactionResponse>} Returns a
    *    promise to the {@link SorobanRpc.GetTransactionResponse} object

--- a/test/unit/server/get_contract_data_test.js
+++ b/test/unit/server/get_contract_data_test.js
@@ -110,7 +110,7 @@ describe("Server#getContractData", function () {
       .getContractData(hexAddress, key, "persistent")
       .then((reply) => done(new Error(`should fail, got: ${reply}`)))
       .catch((error) => {
-        expect(error).to.contain(/unsupported contract/i);
+        expect(error).to.contain(/unsupported contract id/i);
         done();
       });
   });

--- a/test/unit/server/get_contract_data_test.js
+++ b/test/unit/server/get_contract_data_test.js
@@ -105,7 +105,7 @@ describe("Server#getContractData", function () {
   });
 
   it("fails on hex address (was deprecated now unsupported)", function (done) {
-    let hexAddress = '0'.repeat(63) + '1';
+    let hexAddress = "0".repeat(63) + "1";
     this.server
       .getContractData(hexAddress, key, "persistent")
       .then((reply) => done(new Error(`should fail, got: ${reply}`)))

--- a/test/unit/server/get_contract_data_test.js
+++ b/test/unit/server/get_contract_data_test.js
@@ -13,10 +13,7 @@ describe("Server#getContractData", function () {
     this.axiosMock.restore();
   });
 
-  let address =
-    "0000000000000000000000000000000000000000000000000000000000000001";
-  let nonHexAddress =
-    "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5";
+  let address = "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5";
   let key = SorobanClient.xdr.ScVal.scvVec([
     SorobanClient.xdr.ScVal.scvSymbol("Admin"),
   ]);
@@ -107,39 +104,14 @@ describe("Server#getContractData", function () {
       });
   });
 
-  it("key not found Non-hex address", function (done) {
-    this.axiosMock
-      .expects("post")
-      .withArgs(serverUrl, {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "getLedgerEntries",
-        params: [
-          [
-            xdr.LedgerKey.contractData(
-              new xdr.LedgerKeyContractData({
-                contract: new Address(nonHexAddress).toScAddress(),
-                key,
-                durability: xdr.ContractDataDurability.persistent(),
-                bodyType: xdr.ContractEntryBodyType.dataEntry(),
-              })
-            ).toXDR("base64"),
-          ],
-        ],
-      })
-      .returns(Promise.resolve({ data: { result: { entries: [] } } }));
-
+  it("fails on hex address (was deprecated now unsupported)", function (done) {
+    let hexAddress = '0'.repeat(63) + '1';
     this.server
-      .getContractData(nonHexAddress, key, "persistent")
-      .then(function (_response) {
-        done(new Error("Expected error"));
-      })
-      .catch(function (err) {
-        done(
-          err.code == 404
-            ? null
-            : new Error("Expected error code 404, got: " + err.code)
-        );
+      .getContractData(hexAddress, key, "persistent")
+      .then((reply) => done(new Error(`should fail, got: ${reply}`)))
+      .catch((error) => {
+        expect(error).to.contain(/unsupported contract/i);
+        done();
       });
   });
 });

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -5,8 +5,8 @@ describe("Server#simulateTransaction", function () {
     "56199647068161"
   );
 
-  let rawContract = Buffer.alloc(32);
-  let contract = new SorobanClient.Contract(rawContract.toString("hex"));
+  let contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+  let contract = new SorobanClient.Contract(contractId);
   let address = contract.address().toScAddress();
 
   const simulationResponse = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,11 +2846,6 @@ cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
-crc@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/crc/-/crc-4.3.2.tgz#49b7821cbf2cf61dfd079ed93863bbebd5469b9a"
-  integrity sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==
-
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -6588,16 +6583,14 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stellar-base@10.0.0-soroban.4:
-  version "10.0.0-soroban.4"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-soroban.4.tgz#9baeaec1f750473cb0dc00c6fa0f3ec23cf7177d"
-  integrity sha512-Afl2Mlh+aXokIHhy2x67Df5ofbss83oAOHV7pHLI0fsPlxAgs7YtbClzkNxvpnXyxQI77PMIWFJbT17Y3dR/+A==
+stellar-base@10.0.0-soroban.5:
+  version "10.0.0-soroban.5"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-soroban.5.tgz#bf12f3a947ac15fa22a61121a705e80ee7eb4834"
+  integrity sha512-4gASMPVftdtuG4JqrRVgjjUyy/gIzv3FTJxR9Y8jfYi7KaduXn5YwaNjRC3UABlScqh2G1ax5+7NFkHhZXg5oA==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^9.1.1"
     buffer "^6.0.3"
-    crc "^4.3.2"
-    crypto-browserify "^3.12.0"
     js-xdr "^3.0.0"
     sha.js "^2.3.6"
     tweetnacl "^1.0.3"


### PR DESCRIPTION
This is related to stellar/js-stellar-base#650, which fully drops support for the now-deprecated hex encoding method for contracts. The [SEP-23 strkey format](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md#specification) is mandatory, now. You can migrate as such:

```typescript
const strkey = StrKey.encodeContract(Buffer.from(hexContractId, 'hex'));
```

To enforce this, we also upgraded `stellar-base`.