### PR TITLE
Automatically decode XDR structures in simulation responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ A breaking change should be clearly marked in this log.
 
 
 ### Breaking Changes
-* The RPC response schemas for simulation have been upgraded to parse the base64-encoded XDR automatically. Succinctly:
+* The RPC response schemas for simulation have been upgraded to parse the base64-encoded XDR automatically. The full interface changes are in the pull request ([https://github.com/stellar/js-soroban-client/pull/127](#127)), but succinctly:
   - `SimulateTransactionResponse` -> `RawSimulateTransactionResponse`
   - `SimulateHostFunctionResult` -> `RawSimulateHostFunctionResult`
   - Now, `SimulateTransactionResponse` and `SimulateHostFunctionResult` now include the full, decoded XDR structures instead of raw, base64-encoded strings for the relevant fields (e.g. `SimulateTransactionResponse.transactionData` is now an instance of `SorobanDataBuilder`, `events` is now an `xdr.DiagnosticEvent[]` [try out `humanizeEvents` for a friendlier representation of this field])
   - The `SimulateTransactionResponse.results[]` field has been moved to `SimulateTransactionResponse.result?`, since it will always be exactly zero or one result.
+
+Not all schemas have been broken in this manner in order to facilitate user feedback on this approach. Please add your :+1: or :-1: to [#128](https://github.com/stellar/js-soroban-client/issues/128) to provide your perspective on whether or not we should do this for the other response schemas.
+
 
 ## v0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ A breaking change should be clearly marked in this log.
 
 
 ### Breaking Changes
+* `Server.prepareTransaction` now returns a `TransactionBuilder` instance rather than an immutable `Transaction`, in order to facilitate modifying your transaction after assembling it alongside the simulation response ([https://github.com/stellar/js-soroban-client/pull/127](#127)).
+  - The intent is to avoid cloning the transaction again (via `TransactionBuilder.cloneFrom`) if you need to modify parameters such as the storage access footprint.
+  - To migrate your code, just call `.build()` on the return value.
 * The RPC response schemas for simulation have been upgraded to parse the base64-encoded XDR automatically. The full interface changes are in the pull request ([https://github.com/stellar/js-soroban-client/pull/127](#127)), but succinctly:
   - `SimulateTransactionResponse` -> `RawSimulateTransactionResponse`
   - `SimulateHostFunctionResult` -> `RawSimulateHostFunctionResult`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 
+### Breaking Changes
+* The RPC response schemas for simulation have been upgraded to parse the base64-encoded XDR automatically. Succinctly:
+  - `SimulateTransactionResponse` -> `RawSimulateTransactionResponse`
+  - `SimulateHostFunctionResult` -> `RawSimulateHostFunctionResult`
+  - Now, `SimulateTransactionResponse` and `SimulateHostFunctionResult` now include the full, decoded XDR structures instead of raw, base64-encoded strings for the relevant fields (e.g. `SimulateTransactionResponse.transactionData` is now an instance of `SorobanDataBuilder`, `events` is now an `xdr.DiagnosticEvent[]` [try out `humanizeEvents` for a friendlier representation of this field])
+  - The `SimulateTransactionResponse.results[]` field has been moved to `SimulateTransactionResponse.result?`, since it will always be exactly zero or one result.
+
 ## v0.10.1
 
 ### Fixed

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,6 @@ import {
   Address,
   Contract,
   FeeBumpTransaction,
-  SorobanDataBuilder,
   StrKey,
   Transaction,
   xdr,
@@ -18,7 +17,7 @@ import AxiosClient from "./axios";
 import { Friendbot } from "./friendbot";
 import * as jsonrpc from "./jsonrpc";
 import { SorobanRpc } from "./soroban_rpc";
-import { assembleTransaction } from "./transaction";
+import { assembleTransaction, parseRawSimulation } from "./transaction";
 
 export const SUBMIT_TRANSACTION_TIMEOUT = 60 * 1000;
 
@@ -454,24 +453,7 @@ export class Server {
       this.serverURL.toString(),
       "simulateTransaction",
       transaction.toXDR(),
-    ).then((raw) => {
-      return {
-        id: raw.id,
-        error: raw.error,
-        minResourceFee: raw.minResourceFee,
-        latestLedger: raw.latestLedger,
-        cost: raw.cost,
-        transactionData: new SorobanDataBuilder(raw.transactionData),
-        events: raw.events.map(event => xdr.DiagnosticEvent.fromXDR(event, 'base64')),
-        result: raw.results?.map(result => {
-          return {
-            auth: (result.auth ?? []).map(entry =>
-              xdr.SorobanAuthorizationEntry.fromXDR(entry, 'base64')),
-            xdr: xdr.ScVal.fromXDR(result.xdr, 'base64'),
-          };
-        })[0]
-      }
-    });
+    ).then((raw) => parseRawSimulation(raw));
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -566,7 +566,8 @@ export class Server {
     if (!simResponse.result) {
       throw new Error("transaction simulation failed");
     }
-    return assembleTransaction(transaction, passphrase, simResponse);
+
+    return assembleTransaction(transaction, passphrase, simResponse).build();
   }
 
   /**

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -129,16 +129,13 @@ export namespace SorobanRpc {
     transactionData: SorobanDataBuilder;
     events: xdr.DiagnosticEvent[];
     minResourceFee: string;
-    // This will only contain a single element, because only a single
-    // invokeHostFunctionOperation is supported per transaction.
-    //
     // only present if error isn't
     result?: SimulateHostFunctionResult;
     latestLedger: number;
     cost: Cost;
   }
 
-  export interface RawSimulateHostFunctionResult{
+  export interface RawSimulateHostFunctionResult {
     // each string is SorobanAuthorizationEntry XDR in base64
     auth?: string[];
     // invocation response, which is just a hash of the result preimage

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -1,9 +1,10 @@
-import { AssetType } from "stellar-base";
+import { AssetType, SorobanDataBuilder, xdr } from "stellar-base";
 
-// TODO: Better parsing for hashes, and base64-encoded xdr
+// TODO: Better parsing for hashes
 
 /* tslint:disable-next-line:no-namespace */
-/* @namespace SorobanRpc
+/**
+ * @namespace SorobanRpc
  */
 export namespace SorobanRpc {
   export interface Balance {
@@ -118,13 +119,33 @@ export namespace SorobanRpc {
   }
 
   export interface SimulateHostFunctionResult {
-    // each string is SorobanAuthorizationEntry XDR in base64
-    auth?: string[];
-    // function response as SCVal XDR in base64
-    xdr: string;
+    auth: xdr.SorobanAuthorizationEntry[];
+    xdr: xdr.ScVal;
   }
 
   export interface SimulateTransactionResponse {
+    id: string;
+    error?: string;
+    transactionData: SorobanDataBuilder;
+    events: xdr.DiagnosticEvent[];
+    minResourceFee: string;
+    // This will only contain a single element, because only a single
+    // invokeHostFunctionOperation is supported per transaction.
+    //
+    // only present if error isn't
+    result?: SimulateHostFunctionResult;
+    latestLedger: number;
+    cost: Cost;
+  }
+
+  export interface RawSimulateHostFunctionResult{
+    // each string is SorobanAuthorizationEntry XDR in base64
+    auth?: string[];
+    // invocation response, which is just a hash of the result preimage
+    xdr: string;
+  }
+
+  export interface RawSimulateTransactionResponse {
     id: string;
     error?: string;
     // this is SorobanTransactionData XDR in base64
@@ -133,7 +154,7 @@ export namespace SorobanRpc {
     minResourceFee: string;
     // This will only contain a single element, because only a single
     // invokeHostFunctionOperation is supported per transaction.
-    results: SimulateHostFunctionResult[];
+    results?: RawSimulateHostFunctionResult[];
     latestLedger: number;
     cost: Cost;
   }

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -120,7 +120,7 @@ export namespace SorobanRpc {
 
   export interface SimulateHostFunctionResult {
     auth: xdr.SorobanAuthorizationEntry[];
-    xdr: xdr.ScVal;
+    retval: xdr.ScVal;
   }
 
   export interface SimulateTransactionResponse {
@@ -138,7 +138,7 @@ export namespace SorobanRpc {
   export interface RawSimulateHostFunctionResult {
     // each string is SorobanAuthorizationEntry XDR in base64
     auth?: string[];
-    // invocation response, which is just a hash of the result preimage
+    // invocation return value: the ScVal in base64
     xdr: string;
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -107,7 +107,7 @@ function isSorobanTransaction(tx: Transaction): boolean {
     case "invokeHostFunction":
     case "bumpFootprintExpiration":
     case "restoreFootprint":
-      return true;
+      return true
 
     default:
       return false;

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -174,7 +174,7 @@ function cloneSimulation(sim) {
       sim.transactionData.build()
     ),
     result: {
-      auth: sim.result.auth.map(entry =>
+      auth: sim.result.auth.map((entry) =>
         xdr.SorobanAuthorizationEntry.fromXDR(entry.toXDR())
       ),
       retval: xdr.ScVal.fromXDR(sim.result.retval.toXDR()),

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -1,4 +1,4 @@
-const xdr = SorobanClient.xdr;
+const xdr = xdr;
 
 describe("Server#simulateTransaction", function () {
   let keypair = SorobanClient.Keypair.random();
@@ -16,36 +16,39 @@ describe("Server#simulateTransaction", function () {
     events: [],
     latestLedger: 3,
     minResourceFee: "15",
-    transactionData: new SorobanClient.SorobanDataBuilder().build().toXDR('base64'),
-    results: [{
-      auth: [
-        new SorobanClient.xdr.SorobanAuthorizationEntry({
-          // Include a credentials w/ a nonce
-          credentials:
-            new SorobanClient.xdr.SorobanCredentials.sorobanCredentialsAddress(
-              new SorobanClient.xdr.SorobanAddressCredentials({
+    transactionData: new SorobanClient.SorobanDataBuilder()
+      .build()
+      .toXDR("base64"),
+    results: [
+      {
+        auth: [
+          new xdr.SorobanAuthorizationEntry({
+            // Include a credentials w/ a nonce
+            credentials: new xdr.SorobanCredentials.sorobanCredentialsAddress(
+              new xdr.SorobanAddressCredentials({
                 address: address,
-                nonce: new SorobanClient.xdr.Int64(1234),
+                nonce: new xdr.Int64(1234),
                 signatureExpirationLedger: 1,
                 signatureArgs: [],
               })
             ),
-          // Basic fake invocation
-          rootInvocation: new SorobanClient.xdr.SorobanAuthorizedInvocation({
-            function:
-              SorobanClient.xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
-                new SorobanClient.xdr.SorobanAuthorizedContractFunction({
-                  contractAddress: address,
-                  functionName: "test",
-                  args: [],
-                })
-              ),
-            subInvocations: [],
-          }),
-        }).toXDR('base64'),
-      ],
-      xdr: SorobanClient.xdr.ScVal.scvU32(0).toXDR('base64'),
-    }],
+            // Basic fake invocation
+            rootInvocation: new xdr.SorobanAuthorizedInvocation({
+              function:
+                xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+                  new xdr.SorobanAuthorizedContractFunction({
+                    contractAddress: address,
+                    functionName: "test",
+                    args: [],
+                  })
+                ),
+              subInvocations: [],
+            }),
+          }).toXDR("base64"),
+        ],
+        xdr: xdr.ScVal.scvU32(0).toXDR("base64"),
+      },
+    ],
     cost: {
       cpuInsns: "0",
       memBytes: "0",
@@ -57,16 +60,17 @@ describe("Server#simulateTransaction", function () {
     events: simulationResponse.events,
     latestLedger: simulationResponse.latestLedger,
     minResourceFee: simulationResponse.minResourceFee,
-    transactionData:
-      new SorobanClient.SorobanDataBuilder(simulationResponse.transactionData),
+    transactionData: new SorobanClient.SorobanDataBuilder(
+      simulationResponse.transactionData
+    ),
     result: {
-      auth: simulationResponse.results[0].auth.map(
-        entry => SorobanClient.xdr.SorobanAuthorizationEntry.fromXDR(entry, 'base64')
+      auth: simulationResponse.results[0].auth.map((entry) =>
+        xdr.SorobanAuthorizationEntry.fromXDR(entry, "base64")
       ),
-      retval: SorobanClient.xdr.ScVal.fromXDR(simulationResponse.results[0].xdr, 'base64'),
+      retval: xdr.ScVal.fromXDR(simulationResponse.results[0].xdr, "base64"),
     },
     cost: simulationResponse.cost,
-  }
+  };
 
   beforeEach(function () {
     this.server = new SorobanClient.Server(serverUrl);
@@ -83,9 +87,7 @@ describe("Server#simulateTransaction", function () {
       })
         .addOperation(
           SorobanClient.Operation.invokeHostFunction({
-            func: new SorobanClient.xdr.HostFunction.hostFunctionTypeInvokeContract(
-              []
-            ),
+            func: new xdr.HostFunction.hostFunctionTypeInvokeContract([]),
             auth: [],
           })
         )
@@ -130,18 +132,18 @@ describe("Server#simulateTransaction", function () {
       });
   });
 
-  it("works when there are no results", function() {
+  it("works when there are no results", function () {
     const simResponseCopy = JSON.parse(JSON.stringify(simulationResponse));
     simResponseCopy.results = undefined;
 
     const parsedCopy = JSON.parse(JSON.stringify(parsedSimulationResponse));
     parsedCopy.result = undefined;
 
-    const parsed = SorobanClient.parseRawSimulation(simResponseCopy)
+    const parsed = SorobanClient.parseRawSimulation(simResponseCopy);
     expect(parsed).to.deep.equal(parsedCopy);
   });
 
-  it("works with no auth", function(done) {
+  it("works with no auth", function (done) {
     const simResponseCopy = JSON.parse(JSON.stringify(simulationResponse));
     simResponseCopy.results[0].auth = undefined;
 
@@ -153,9 +155,7 @@ describe("Server#simulateTransaction", function () {
         method: "simulateTransaction",
         params: [this.blob],
       })
-      .returns(
-        Promise.resolve({ data: { id: 1, result: simResponseCopy } })
-      );
+      .returns(Promise.resolve({ data: { id: 1, result: simResponseCopy } }));
 
     this.server
       .simulateTransaction(this.transaction)
@@ -163,14 +163,16 @@ describe("Server#simulateTransaction", function () {
         const parsedCopy = JSON.parse(JSON.stringify(parsedSimulationResponse));
         parsedCopy.result.auth = [];
 
-        expect(response).to.be.deep.equal(parsedCopy,
-          `.result.auth should be [], got ${JSON.stringify(response)}`);
+        expect(response).to.be.deep.equal(
+          parsedCopy,
+          `.result.auth should be [], got ${JSON.stringify(response)}`
+        );
         done();
       })
       .catch(function (err) {
         done(err);
       });
-  })
+  });
 
   xit("adds metadata - tx was too small and was immediately deleted");
   xit("adds metadata, order immediately fills");

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -1,4 +1,4 @@
-const xdr = xdr;
+const xdr = SorobanClient.xdr; // shorthand
 
 describe("Server#simulateTransaction", function () {
   let keypair = SorobanClient.Keypair.random();
@@ -134,10 +134,10 @@ describe("Server#simulateTransaction", function () {
 
   it("works when there are no results", function () {
     const simResponseCopy = JSON.parse(JSON.stringify(simulationResponse));
-    simResponseCopy.results = undefined;
+    delete simResponseCopy.results;
 
     const parsedCopy = JSON.parse(JSON.stringify(parsedSimulationResponse));
-    parsedCopy.result = undefined;
+    delete parsedCopy.result;
 
     const parsed = SorobanClient.parseRawSimulation(simResponseCopy);
     expect(parsed).to.deep.equal(parsedCopy);
@@ -145,33 +145,13 @@ describe("Server#simulateTransaction", function () {
 
   it("works with no auth", function (done) {
     const simResponseCopy = JSON.parse(JSON.stringify(simulationResponse));
-    simResponseCopy.results[0].auth = undefined;
+    delete simResponseCopy.results;
 
-    this.axiosMock
-      .expects("post")
-      .withArgs(serverUrl, {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "simulateTransaction",
-        params: [this.blob],
-      })
-      .returns(Promise.resolve({ data: { id: 1, result: simResponseCopy } }));
+    const parsedCopy = JSON.parse(JSON.stringify(parsedSimulationResponse));
+    parsedCopy.result.auth = [];
 
-    this.server
-      .simulateTransaction(this.transaction)
-      .then(function (response) {
-        const parsedCopy = JSON.parse(JSON.stringify(parsedSimulationResponse));
-        parsedCopy.result.auth = [];
-
-        expect(response).to.be.deep.equal(
-          parsedCopy,
-          `.result.auth should be [], got ${JSON.stringify(response)}`
-        );
-        done();
-      })
-      .catch(function (err) {
-        done(err);
-      });
+    const parsed = SorobanClient.parseRawSimulation(simResponseCopy);
+    expect(parsed).to.be.deep.equal(parsedCopy);
   });
 
   xit("adds metadata - tx was too small and was immediately deleted");

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -10,20 +10,7 @@ describe("Server#simulateTransaction", function () {
   let address = contract.address().toScAddress();
 
   const simulationResponse = {
-    transactionData: new SorobanClient.xdr.SorobanTransactionData({
-      resources: new SorobanClient.xdr.SorobanResources({
-        footprint: new SorobanClient.xdr.LedgerFootprint({
-          readOnly: [],
-          readWrite: [],
-        }),
-        instructions: 0,
-        readBytes: 0,
-        writeBytes: 0,
-        extendedMetaDataSizeBytes: 0,
-      }),
-      refundableFee: SorobanClient.xdr.Int64.fromString("0"),
-      ext: new SorobanClient.xdr.ExtensionPoint(0),
-    }).toXDR("base64"),
+    transactionData: new SorobanClient.SorobanDataBuilder(),
     events: [],
     minResourceFee: "15",
     result: {
@@ -51,9 +38,9 @@ describe("Server#simulateTransaction", function () {
               ),
             subInvocations: [],
           }),
-        }).toXDR("base64"),
+        })
       ],
-      xdr: SorobanClient.xdr.ScVal.scvU32(0).toXDR().toString("base64"),
+      xdr: SorobanClient.xdr.ScVal.scvU32(0),
     },
     latestLedger: 3,
     cost: {

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -1,7 +1,7 @@
 const xdr = SorobanClient.xdr; // shorthand
 
 describe("assembleTransaction", () => {
-  xit('works with keybump transactions');
+  xit("works with keybump transactions");
 
   const scAddress = new SorobanClient.Address(
     "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI"
@@ -36,13 +36,13 @@ describe("assembleTransaction", () => {
     .build();
 
   const simulationResponse = {
-    transactionData: sorobanTransactionData.toXDR('base64'),
+    transactionData: sorobanTransactionData.toXDR("base64"),
     events: [],
     minResourceFee: "115",
     results: [
       {
         auth: [fnAuth],
-        xdr: xdr.ScVal.scvU32(0).toXDR('base64')
+        xdr: xdr.ScVal.scvU32(0).toXDR("base64"),
       },
     ],
     latestLedger: 3,

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -33,29 +33,20 @@ describe("assembleTransaction", () => {
     }),
   });
 
-  const sorobanTransactionData = new xdr.SorobanTransactionData({
-    resources: new xdr.SorobanResources({
-      footprint: new xdr.LedgerFootprint({
-        readOnly: [],
-        readWrite: [],
-      }),
-      instructions: 0,
-      readBytes: 5,
-      writeBytes: 0,
-      extendedMetaDataSizeBytes: 0,
-    }),
-    refundableFee: xdr.Int64.fromString("0"),
-    ext: new xdr.ExtensionPoint(0),
-  });
+  const sorobanTransactionData = new SorobanClient.SorobanDataBuilder()
+    .setResources(0, 5, 0, 0)
+    .build();
 
   const simulationResponse = {
-    transactionData: sorobanTransactionData.toXDR("base64"),
+    transactionData: new SorobanClient.SorobanDataBuilder(
+      sorobanTransactionData
+    ),
     events: [],
     minResourceFee: "115",
     results: [
       {
-        auth: [fnAuth.toXDR("base64")],
-        xdr: xdr.ScVal.scvU32(0).toXDR().toString("base64"),
+        auth: [fnAuth],
+        xdr: xdr.ScVal.scvU32(0),
       },
     ],
     latestLedger: 3,

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -1,9 +1,7 @@
 const xdr = SorobanClient.xdr; // shorthand
 
 describe("assembleTransaction", () => {
-  describe("FeeBumpTransaction", () => {
-    // TODO: Add support for fee bump transactions
-  });
+  xit('works with keybump transactions');
 
   const scAddress = new SorobanClient.Address(
     "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI"
@@ -31,22 +29,20 @@ describe("assembleTransaction", () => {
         ),
       subInvocations: [],
     }),
-  });
+  }).toXDR();
 
   const sorobanTransactionData = new SorobanClient.SorobanDataBuilder()
     .setResources(0, 5, 0, 0)
     .build();
 
   const simulationResponse = {
-    transactionData: new SorobanClient.SorobanDataBuilder(
-      sorobanTransactionData
-    ),
+    transactionData: sorobanTransactionData.toXDR('base64'),
     events: [],
     minResourceFee: "115",
     results: [
       {
         auth: [fnAuth],
-        xdr: xdr.ScVal.scvU32(0),
+        xdr: xdr.ScVal.scvU32(0).toXDR('base64')
       },
     ],
     latestLedger: 3,
@@ -55,6 +51,7 @@ describe("assembleTransaction", () => {
       memBytes: "0",
     },
   };
+
   describe("Transaction", () => {
     const networkPassphrase = SorobanClient.Networks.TESTNET;
     const source = new SorobanClient.Account(
@@ -84,7 +81,7 @@ describe("assembleTransaction", () => {
         txn,
         networkPassphrase,
         simulationResponse
-      );
+      ).build();
 
       // validate it auto updated the tx fees from sim response fees
       // since it was greater than tx.fee
@@ -102,7 +99,7 @@ describe("assembleTransaction", () => {
         txn,
         networkPassphrase,
         simulationResponse
-      );
+      ).build();
 
       expect(
         result
@@ -147,7 +144,7 @@ describe("assembleTransaction", () => {
         txn,
         networkPassphrase,
         simulateResp
-      );
+      ).build();
 
       expect(
         result
@@ -182,7 +179,7 @@ describe("assembleTransaction", () => {
           minResourceFee: "0",
           results: [],
           latestLedger: 3,
-        });
+        }).build();
         expect.fail();
       }).to.throw(/unsupported transaction/i);
     });
@@ -210,7 +207,7 @@ describe("assembleTransaction", () => {
           txn,
           networkPassphrase,
           simulationResponse
-        );
+        ).build();
         expect(tx.operations[0].type).to.equal(op.body().switch().name);
       });
     });
@@ -221,7 +218,7 @@ describe("assembleTransaction", () => {
         txn,
         networkPassphrase,
         simulationResponse
-      );
+      ).build();
 
       expect(tx.operations[0].auth.length).to.equal(
         3,


### PR DESCRIPTION
The RPC response schemas for simulation have been upgraded to parse the base64-encoded XDR automatically. Succinctly,
  - `SimulateTransactionResponse` -> `RawSimulateTransactionResponse`
  - `SimulateHostFunctionResult` -> `RawSimulateHostFunctionResult`
  - Now, `SimulateTransactionResponse` and `SimulateHostFunctionResult` now include the full, decoded XDR structures instead of raw, base64-encoded strings for the relevant fields

Here is the full list of changed fields:

```diff
  export interface SimulateHostFunctionResult {
-    auth?: string[];
-    xdr: string;
+    auth: xdr.SorobanAuthorizationEntry[];
+    xdr: xdr.ScVal;
  }

  export interface SimulateTransactionResponse {
-    transactionData: string;
+    transactionData: SorobanDataBuilder;
-    events: string[];
+    events: xdr.DiagnosticEvent[];
-    results: SimulateHostFunctionResult[];
+    result?: SimulateHostFunctionResult;
  }
```

The true, raw, underlying schema is still accessible by adding the `Raw` prefix to the interface name.