### PR TITLE
Add fallback parsing to edge cases in `simulateTransaction`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 
+## v0.11.3
+
+### Fixed
+* The `Server.simulateTransaction` would fail unexpectedly if the backing RPC server did not simulate the transaction correctly. When this occurs, the `result?.retval` field will be `scvVoid` ([TODO]()).
+
+### Added
+* Adds a `Server._simulateTransaction()` method to make a raw JSON-RPC request, in case users would like to inspect the raw results without parsing abstractions ([TODO]()).
+
+
 ## v0.11.2
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soroban-client",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "A library for working with Stellar's Soroban RPC servers.",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "homepage": "https://github.com/stellar/js-soroban-client",
@@ -67,7 +67,7 @@
     ],
     "sort": true,
     "recursive": true,
-    "timeout": 60000
+    "timeout": 10000
   },
   "nyc": {
     "instrument": false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -486,13 +486,34 @@ export class Server {
   public async simulateTransaction(
     transaction: Transaction | FeeBumpTransaction,
   ): Promise<SorobanRpc.SimulateTransactionResponse> {
-    return await jsonrpc
+    return this._simulateTransaction(transaction)
+      .then((raw) => parseRawSimulation(raw));
+  }
+
+  /**
+   * Performs the same thing as {@link Server.simulateTransaction}, but without
+   * doing helpful parsing of the resulting schema.
+   *
+   * This can be useful to work around bugs in the abstraction layers if you
+   * just want to communicate directly with the RPC server endpoints.
+   *
+   * @param {Transaction | FeeBumpTransaction} transaction - The transaction to
+   *    simulate. It should include exactly one operation, which must be one of
+   *    {@link xdr.InvokeHostFunctionOp}, {@link xdr.BumpFootprintExpirationOp},
+   *    or {@link xdr.RestoreFootprintOp}. Any provided footprint will be
+   *    ignored.
+   *
+   * @returns {SorobanRpc.RawSimulateTransactionResponse}
+   */
+  public async _simulateTransaction(
+    transaction: Transaction | FeeBumpTransaction,
+  ): Promise<SorobanRpc.RawSimulateTransactionResponse> {
+    return jsonrpc
       .post<SorobanRpc.RawSimulateTransactionResponse>(
         this.serverURL.toString(),
         "simulateTransaction",
         transaction.toXDR(),
-      )
-      .then((raw) => parseRawSimulation(raw));
+      );
   }
 
   /**

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -159,6 +159,17 @@ export namespace SorobanRpc {
 
   export interface SimulateHostFunctionResult {
     auth: xdr.SorobanAuthorizationEntry[];
+
+    /**
+     * The parsed return value from the simulation.
+     *
+     * If an error occurs while parsing it, this may be `void`. This typically
+     * indicates a server-side failure, so you can use
+     * {@link Server._simulateTransaction} to acquire a raw RPC result.
+     *
+     * @see scValToNative
+     * @see scValToBigInt
+     */
     retval: xdr.ScVal;
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -151,7 +151,9 @@ export function parseRawSimulation(
           auth: (result.auth ?? []).map((entry) =>
             xdr.SorobanAuthorizationEntry.fromXDR(entry, "base64")
           ),
-          retval: xdr.ScVal.fromXDR(result.xdr, "base64"),
+          retval: result.xdr
+            ? xdr.ScVal.fromXDR(result.xdr, "base64")
+            : xdr.ScVal.scvVoid()
         };
       })[0], // only if present
     }),

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -1,4 +1,4 @@
-const xdr = SorobanClient.xdr; // shorthand
+const { xdr } = SorobanClient; // shorthand
 
 describe('Server#simulateTransaction', function () {
   let keypair = SorobanClient.Keypair.random();


### PR DESCRIPTION
This works around a Soroban RPC bug (https://github.com/stellar/soroban-tools/issues/933) in which `results` will have a result object that is invalid. The `parseRawSimulation` abstraction assumes a valid schema, so this changes `retval` to be a `void` `ScVal` in case of an invalid response.

This also adds a way to make the raw JSON RPC request again, `Server._simulateTransaction()`, in order to prevent any internal parsing errors from affecting development. Developers can then just look at the JSON directly (it also helps with debugging).