### PR TITLE
fix(spec): unwrap result when parsing return value

### DIFF
--- a/src/contract_spec.ts
+++ b/src/contract_spec.ts
@@ -146,7 +146,7 @@ export class ContractSpec {
     if (output.switch().value === xdr.ScSpecType.scSpecTypeResult().value) {
       return this.scValToNative(
         val,
-        (output.value() as xdr.ScSpecTypeResult).okType()
+        output.result().okType()
       );
     }
     return this.scValToNative(val, output);

--- a/src/contract_spec.ts
+++ b/src/contract_spec.ts
@@ -143,6 +143,12 @@ export class ContractSpec {
       throw new Error(`Multiple outputs not supported`);
     }
     let output = outputs[0];
+    if (output.switch().value === xdr.ScSpecType.scSpecTypeResult().value) {
+      return this.scValToNative(
+        val,
+        (output.value() as xdr.ScSpecTypeResult).okType()
+      );
+    }
     return this.scValToNative(val, output);
   }
 


### PR DESCRIPTION
This PR unwraps the result type's ok type so that it can be parsed correctly. The error type is used when if it throws.
fixes: https://github.com/stellar/soroban-tools/issues/935