### PR TITLE
Fix stellar-base reference in GH Pages doc generation

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: stellar/js-stellar-base
-          ref: soroban
+          ref: master
           path: js-stellar-base
 
       - name: Install Node 16


### PR DESCRIPTION
The soroban branch is gone, causing a failure: https://github.com/stellar/js-soroban-client/actions/runs/6176193529/job/16764641647