### PR TITLE
Prepare v1.0.0-beta.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 
+## v1.0.0-beta.1
+
+### Fixed
+* This upgrades `stellar-base` which has a critical bugfix for `Contract.call()` not generating valid operations ([TODO](), [stellar-base#692](https://github.com/stellar/js-stellar-base/pull/692)).
+
+
 ## v1.0.0-beta.0
 **Note:** This version is currently only compatible with Stellar networks running `stellar-core@19.13.1-1481.3acf6dd26`, which corresponds to Preview 11, the final Protocol 20 preview (using stellar/stellar-xdr@9ac0264).
 

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "axios": "^1.4.0",
     "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",
-    "stellar-base": "v10.0.0-beta.0",
+    "stellar-base": "v10.0.0-beta.1",
     "urijs": "^1.19.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@babel/preset-env": "^7.22.15",
     "@babel/preset-typescript": "^7.22.15",
     "@babel/register": "^7.22.15",
-    "@definitelytyped/dtslint": "^0.0.177",
+    "@definitelytyped/dtslint": "^0.0.178",
     "@istanbuljs/nyc-config-babel": "3.0.0",
     "@stellar/tsconfig": "^1.0.2",
     "@types/chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soroban-client",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "A library for working with Stellar's Soroban RPC servers.",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "homepage": "https://github.com/stellar/js-soroban-client",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6636,10 +6636,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stellar-base@v10.0.0-beta.0:
-  version "10.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-beta.0.tgz#c8663996ef6fcfd569977f4534688c94b3939a39"
-  integrity sha512-YYUUCERjlok4yzCC3XXuvfvMw1POHCXE6JELjYgFGMaMx8IS8pAN9mdW/H7n1Sdo1c57jaDfPwZYFrgzRtU4kQ==
+stellar-base@v10.0.0-beta.1:
+  version "10.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-beta.1.tgz#5b4209fbc44b8af82dd3ee8b7f6f4397126d8c3b"
+  integrity sha512-zXC5AsbUsLi57JruyeIMv23s3iUxq/P2ZFrSJ+FerLIZjSAjY8EDs4zwY4LCuu7swUu46Lm8GK6sqxUZCPekHw==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^9.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,27 +1029,27 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@definitelytyped/dts-critic@^0.0.177":
-  version "0.0.177"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.177.tgz#0c8b2d9772c1f27242c47f0866fa66267d7854b2"
-  integrity sha512-EcKoBzaHMX4MwnPmg1yVNKkTG50ZWoLpPocejl0+AoWZNfk0f1T5/YTcabQ/pC7vrMlN6+C9EufTOs82gJ9ZIA==
+"@definitelytyped/dts-critic@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.178.tgz#79e82ef35615b1534da979eb925a6130e1977d94"
+  integrity sha512-1JiY6giD2qLYxDPSWPbZiICzmTX+cHBNMXf09SeY6CJX0kZPcAkX+Uhc64HSqlhutECRWy7SdQCp/NP3xVOt4Q==
   dependencies:
-    "@definitelytyped/header-parser" "^0.0.177"
+    "@definitelytyped/header-parser" "^0.0.178"
     command-exists "^1.2.8"
     rimraf "^3.0.2"
     semver "^7.5.2"
     tmp "^0.2.1"
     yargs "^15.3.1"
 
-"@definitelytyped/dtslint@^0.0.177":
-  version "0.0.177"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.177.tgz#0a83ce54a6ff212617f8eea44dce9b22f1862df5"
-  integrity sha512-ocla41rNWXp9ZyuxhgtFHG+YKkNB1ZKBgFxEHZlRcoFxeiYRsMNe2OSMlubhUUEs7K7A83Vy7WyntNW1DwmEWg==
+"@definitelytyped/dtslint@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.178.tgz#9e76093ed0913d3b0e78fefb834d2e3d86bb6246"
+  integrity sha512-IK4IqJSIY6wS+8Tg0hIuwAltPs0ZIWibMd3CSurQ8E1gNvuXaR48xjsjFVh2R8pxGrIR75mJ5o6H1GjxFZwK1A==
   dependencies:
-    "@definitelytyped/dts-critic" "^0.0.177"
-    "@definitelytyped/header-parser" "^0.0.177"
-    "@definitelytyped/typescript-versions" "^0.0.177"
-    "@definitelytyped/utils" "^0.0.177"
+    "@definitelytyped/dts-critic" "^0.0.178"
+    "@definitelytyped/header-parser" "^0.0.178"
+    "@definitelytyped/typescript-versions" "^0.0.178"
+    "@definitelytyped/utils" "^0.0.178"
     "@typescript-eslint/eslint-plugin" "^5.55.0"
     "@typescript-eslint/parser" "^5.55.0"
     "@typescript-eslint/types" "^5.56.0"
@@ -1062,26 +1062,26 @@
     tslint "5.14.0"
     yargs "^15.1.0"
 
-"@definitelytyped/header-parser@^0.0.177":
-  version "0.0.177"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.177.tgz#b9d2762800acc395237d6acc4458bcf640487f6e"
-  integrity sha512-siVtuvnQxXr4KhD14VV7AzFR0Xb+qcRxJWRQ4AogGkPakd5/ufljAXJ6fBq6HRB57Vy4MmgV9R0irfcMhdaK1A==
+"@definitelytyped/header-parser@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.178.tgz#2cfd170a33b014d686135673fa7fac837cfe5556"
+  integrity sha512-16FFuaWW2Hq+a0Abyt+9gvPAT0w/ezy4eph3RbtLSqxH3T/UHDla1jgnp1DMvfNeBWaIqHxcr+Vrr7BPquw7mw==
   dependencies:
-    "@definitelytyped/typescript-versions" "^0.0.177"
+    "@definitelytyped/typescript-versions" "^0.0.178"
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.177":
-  version "0.0.177"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.177.tgz#4ca225debaaad05f0df855c140b63f664a3a9791"
-  integrity sha512-PcSKwrB0zhpFq9KadHU7iVkqszg/4TqDlF+xrXNsMpFk523RC7S7HXdPNR3j55774fwvoIRudMbr96v2J+WNKg==
+"@definitelytyped/typescript-versions@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.178.tgz#98a92f2251f18b32122e808b968ca8e009d3b123"
+  integrity sha512-pPXy3z5gE4xnVgqIRApFcQ6M6kqtRK1gnqyGx/I0Yo1CH8RAsRvumCDB/KiZmQDpCHiy//E9dOIUFdquvC5t7g==
 
-"@definitelytyped/utils@^0.0.177":
-  version "0.0.177"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.177.tgz#c6e53cdb7b639a532371587691e11e78fe057484"
-  integrity sha512-okfO4lAV3rRnvCYYqfPT3ZSqfM4Wwg+02ClzszV5AV0htYKiDn8KpdfM73Fm2DCoqeKuKlMPmtc5VtuRK6vCRg==
+"@definitelytyped/utils@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.178.tgz#f403be41816690246a4e0244d125a0084b16462a"
+  integrity sha512-nYg3E51XpTodS0/5w5r1wM/DhPYhyqa9BP8ili4XgB5s9j4v4mDPX9Jwjns2q24derBvyhdUpzshKDh43aqwZw==
   dependencies:
-    "@definitelytyped/typescript-versions" "^0.0.177"
+    "@definitelytyped/typescript-versions" "^0.0.178"
     "@qiwi/npm-registry-client" "^8.9.1"
     "@types/node" "^14.14.35"
     charm "^1.0.2"


### PR DESCRIPTION
Shoutout to the shortest-lived beta of all time :sunglasses: 

This includes critical bugfixes from stellar-base, see [stellar-base#693](https://github.com/stellar/js-stellar-base/pull/693/files).