### PR TITLE
Properly parse `simulateTransaction` response variations

### DIFF
--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -68,9 +68,9 @@ export namespace SorobanRpc {
 
   interface GetAnyTransactionResponse {
     status: GetTransactionStatus;
-    latestLedger: number;
+    latestLedger: string;
     latestLedgerCloseTime: number;
-    oldestLedger: number;
+    oldestLedger: string;
     oldestLedgerCloseTime: number;
   }
 
@@ -98,9 +98,9 @@ export namespace SorobanRpc {
 
   export interface RawGetTransactionResponse {
     status: GetTransactionStatus;
-    latestLedger: number;
+    latestLedger: string;
     latestLedgerCloseTime: number;
-    oldestLedger: number;
+    oldestLedger: string;
     oldestLedgerCloseTime: number;
 
     // the fields below are set if status is SUCCESS
@@ -186,7 +186,7 @@ export namespace SorobanRpc {
     id: string;
 
     /** always present: the LCL known to the server when responding */
-    latestLedger: number;
+    latestLedger: string;
 
     /**
      * The field is always present, but may be empty in cases where:
@@ -195,6 +195,9 @@ export namespace SorobanRpc {
      * @see {@link humanizeEvents}
      */
     events: xdr.DiagnosticEvent[];
+
+    /** a private field to mark the schema as parsed */
+    _parsed: boolean;
   }
 
   /** Includes simplified fields only present on success. */
@@ -245,7 +248,8 @@ export namespace SorobanRpc {
 
   export function isSimulationRestore(sim: SimulateTransactionResponse):
     sim is SimulateTransactionRestoreResponse {
-    return isSimulationSuccess(sim) && 'restorePreamble' in sim;
+    return isSimulationSuccess(sim) && 'restorePreamble' in sim &&
+      !!sim.restorePreamble.transactionData;
   }
 
   interface RawSimulateHostFunctionResult {
@@ -258,7 +262,7 @@ export namespace SorobanRpc {
   /** @see https://soroban.stellar.org/api/methods/simulateTransaction#returns */
   export interface RawSimulateTransactionResponse {
     id: string;
-    latestLedger: number;
+    latestLedger: string;
     error?: string;
     // this is an xdr.SorobanTransactionData in base64
     transactionData?: string;

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -122,7 +122,7 @@ export namespace SorobanRpc {
   }
 
   export interface GetEventsResponse {
-    latestLedger: number;
+    latestLedger: string;
     events: EventResponse[];
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -121,6 +121,7 @@ export function parseRawSimulation(
 
   // shared across all responses
   let base: SorobanRpc.BaseSimulateTransactionResponse = {
+    _parsed: true,
     id: sim.id,
     latestLedger: sim.latestLedger,
     events: sim.events?.map(
@@ -171,7 +172,7 @@ function parseSuccessful(
     )
   };
 
-  if (!sim.restorePreamble) {
+  if (!sim.restorePreamble || sim.restorePreamble.transactionData === '') {
     return success;
   }
 
@@ -187,29 +188,12 @@ function parseSuccessful(
   };
 }
 
-
-function isSimulationRaw(
+export function isSimulationRaw(
   sim:
     | SorobanRpc.SimulateTransactionResponse
     | SorobanRpc.RawSimulateTransactionResponse
 ): sim is SorobanRpc.RawSimulateTransactionResponse {
-  const asGud = sim as SorobanRpc.SimulateTransactionRestoreResponse;
-  const asRaw = sim as SorobanRpc.RawSimulateTransactionResponse;
-
-  // lazy checks to determine type: check existence of parsed-only fields note
-  return (
-    asRaw.restorePreamble !== undefined ||
-    !(
-      asGud.restorePreamble !== undefined ||
-      asGud.result !== undefined ||
-      typeof asGud.transactionData !== 'string'
-    ) ||
-    (asRaw.error !== undefined && (
-      !asRaw.events?.length ||
-      typeof asRaw.events![0] === 'string'
-    )) ||
-    (asRaw.results ?? []).length > 0
-  );
+  return !(sim as SorobanRpc.SimulateTransactionResponse)._parsed;
 }
 
 function isSorobanTransaction(tx: Transaction): boolean {

--- a/test/unit/server/simulate_transaction_test.js
+++ b/test/unit/server/simulate_transaction_test.js
@@ -238,32 +238,33 @@ function invokeSimulationResponseWithRestoration(address) {
   };
 }
 
-describe('works with real responses', function() {
+describe('works with real responses', function () {
   const schema = {
-    "transactionData": "AAAAAAAAAAIAAAAGAAAAAa/6eoLeofDK5ksPljSZ7t/rAj/XR18e40fCB9LBugstAAAAFAAAAAEAAAAHqA0LEZLq3WL+N3rBQLTWuPqdV3Vv6XIAGeBJaz1wMdsAAAAAABg1gAAAAxwAAAAAAAAAAAAAAAk=",
-    "minResourceFee": "27889",
-    "events": [
-      "AAAAAQAAAAAAAAAAAAAAAgAAAAAAAAADAAAADwAAAAdmbl9jYWxsAAAAAA0AAAAgr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAAPAAAABWhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA==",
-      "AAAAAQAAAAAAAAABr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAACAAAAAAAAAAIAAAAPAAAACWZuX3JldHVybgAAAAAAAA8AAAAFaGVsbG8AAAAAAAAQAAAAAQAAAAIAAAAPAAAABUhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA=="
+    transactionData:
+      'AAAAAAAAAAIAAAAGAAAAAa/6eoLeofDK5ksPljSZ7t/rAj/XR18e40fCB9LBugstAAAAFAAAAAEAAAAHqA0LEZLq3WL+N3rBQLTWuPqdV3Vv6XIAGeBJaz1wMdsAAAAAABg1gAAAAxwAAAAAAAAAAAAAAAk=',
+    minResourceFee: '27889',
+    events: [
+      'AAAAAQAAAAAAAAAAAAAAAgAAAAAAAAADAAAADwAAAAdmbl9jYWxsAAAAAA0AAAAgr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAAPAAAABWhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA==',
+      'AAAAAQAAAAAAAAABr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAACAAAAAAAAAAIAAAAPAAAACWZuX3JldHVybgAAAAAAAA8AAAAFaGVsbG8AAAAAAAAQAAAAAQAAAAIAAAAPAAAABUhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA=='
     ],
-    "results": [
+    results: [
       {
-        "auth": [],
-        "xdr": "AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFQWxvaGEAAAA="
+        auth: [],
+        xdr: 'AAAAEAAAAAEAAAACAAAADwAAAAVIZWxsbwAAAAAAAA8AAAAFQWxvaGEAAAA='
       }
     ],
-    "cost": {
-      "cpuInsns": "1322134",
-      "memBytes": "1207047"
+    cost: {
+      cpuInsns: '1322134',
+      memBytes: '1207047'
     },
-    "restorePreamble": {
-      "transactionData": "",
-      "minResourceFee": "0"
+    restorePreamble: {
+      transactionData: '',
+      minResourceFee: '0'
     },
-    "latestLedger": "2634"
+    latestLedger: '2634'
   };
 
-  it('parses the schema', function() {
+  it('parses the schema', function () {
     expect(SorobanClient.isSimulationRaw(schema)).to.be.true;
 
     const parsed = SorobanClient.parseRawSimulation(schema);
@@ -276,4 +277,4 @@ describe('works with real responses', function() {
     expect(parsed.events[0]).to.be.instanceOf(xdr.DiagnosticEvent);
     expect(parsed.restorePreamble).to.be.undefined;
   });
-})
+});


### PR DESCRIPTION
This modifies the response parsing to simply attach a `_parsed` field onto the parsed structure, simplifying the error-prone schema detection mechanism from before.

It also updates various TypeScript definitions with the correct field types: latestLedger is a string, not a number, in most responses.