### PR TITLE
Automatically decode XDR structures for `Server.getEvents`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { AxiosClient, version } from "./axios";
 export * from "./transaction";
 
 // export is necessary for testing, but it may be useful for others
+export { parseEvents } from "./server";
 export { parseRawSimulation } from "./parsers";
 
 // expose classes and functions from stellar-base

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,7 @@ export { AxiosClient, version } from "./axios";
 export * from "./transaction";
 
 // export is necessary for testing, but it may be useful for others
-export { parseEvents } from "./server";
-export { parseRawSimulation } from "./parsers";
+export { parseRawSimulation, parseRawEvents } from "./parsers";
 
 // expose classes and functions from stellar-base
 export * from "stellar-base";

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,5 +1,21 @@
-import { xdr, SorobanDataBuilder } from 'stellar-base';
+import { xdr, Contract, SorobanDataBuilder } from 'stellar-base';
 import { SorobanRpc } from './soroban_rpc';
+
+
+export function parseRawEvents(r: SorobanRpc.RawGetEventsResponse): SorobanRpc.GetEventsResponse {
+  return {
+    latestLedger: r.latestLedger,
+    events: (r.events ?? []).map(evt => {
+      return {
+        ...evt,
+        contractId: new Contract(evt.contractId),
+        topic: evt.topic.map(topic => xdr.ScVal.fromXDR(topic, 'base64')),
+        value: xdr.DiagnosticEvent.fromXDR(evt.value.xdr, 'base64')
+      };
+    }),
+  };
+}
+
 
 export function parseRawLedgerEntries(
   raw: SorobanRpc.RawGetLedgerEntriesResponse

--- a/src/server.ts
+++ b/src/server.ts
@@ -386,6 +386,12 @@ export class Server {
   public async getEvents(
     request: Server.GetEventsRequest,
   ): Promise<SorobanRpc.GetEventsResponse> {
+    return this._getEvents(request).then(parseRawEvents);
+  }
+
+  public async _getEvents(
+    request: Server.GetEventsRequest,
+  ): Promise<SorobanRpc.RawGetEventsResponse> {
     // TODO: It'd be nice if we could do something to infer the types of filter
     // arguments a user wants, e.g. converting something like "transfer/*/42"
     // into the base64-encoded `ScVal` equivalents by inferring that the first
@@ -403,7 +409,7 @@ export class Server {
         },
         ...(request.startLedger && { startLedger: request.startLedger.toString() }),
       }
-    ).then(parseRawEvents);
+    );
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -733,10 +733,10 @@ function findCreatedAccountSequenceInTransactionMeta(
   throw new Error("No account created in transaction");
 }
 
-function parseEvents(r: SorobanRpc.RawGetEventsResponse): SorobanRpc.GetEventsResponse {
+export function parseEvents(r: SorobanRpc.RawGetEventsResponse): SorobanRpc.GetEventsResponse {
   return {
     latestLedger: r.latestLedger,
-    events: r.events.map(evt => {
+    events: (r.events ?? []).map(evt => {
       return {
         ...evt,
         contractId: new Contract(evt.contractId),

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -1,4 +1,4 @@
-import { AssetType, SorobanDataBuilder, xdr } from "stellar-base";
+import { AssetType, Contract, SorobanDataBuilder, xdr } from "stellar-base";
 
 // TODO: Better parsing for hashes
 
@@ -137,18 +137,32 @@ export namespace SorobanRpc {
     events: EventResponse[];
   }
 
-  export interface EventResponse {
+  interface EventResponse extends BaseEventResponse {
+    contractId: Contract,
+    topic: xdr.ScVal[];
+    value: xdr.DiagnosticEvent;
+  }
+
+  export interface RawGetEventsResponse {
+    latestLedger: string;
+    events: RawEventResponse[];
+  }
+
+  interface BaseEventResponse {
+    id: string;
     type: EventType;
     ledger: string;
     ledgerClosedAt: string;
-    contractId: string;
-    id: string;
     pagingToken: string;
     inSuccessfulContractCall: boolean;
+  }
+
+  interface RawEventResponse extends BaseEventResponse {
+    contractId: string;
     topic: string[];
     value: {
       xdr: string;
-    };
+    }
   }
 
   export interface RequestAirdropResponse {

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -162,7 +162,7 @@ export namespace SorobanRpc {
     topic: string[];
     value: {
       xdr: string;
-    }
+    };
   }
 
   export interface RequestAirdropResponse {

--- a/test/unit/server/get_events_test.js
+++ b/test/unit/server/get_events_test.js
@@ -12,7 +12,7 @@ describe('Server#getEvents', function () {
   });
 
   it('requests the correct endpoint', function (done) {
-    let result = { events: [] };
+    let result = { latestLedger: 0, events: [] };
     setupMock(
       this.axiosMock,
       {
@@ -35,7 +35,10 @@ describe('Server#getEvents', function () {
   });
 
   it('can build wildcard filters', function (done) {
-    let result = filterEvents(getEventsResponseFixture, '*/*');
+    let result = {
+      latestLedger: 1,
+      events: filterEvents(getEventsResponseFixture, '*/*'),
+    };
 
     setupMock(
       this.axiosMock,
@@ -61,17 +64,20 @@ describe('Server#getEvents', function () {
         ]
       })
       .then(function (response) {
-        expect(response).to.be.deep.equal(result);
+        expect(response).to.be.deep.equal(parseEvents(result));
         done();
       })
       .catch(done);
   });
 
   it('can build matching filters', function (done) {
-    let result = filterEvents(
-      getEventsResponseFixture,
-      'AAAABQAAAAh0cmFuc2Zlcg==/AAAAAQB6Mcc='
-    );
+    let result = {
+      latestLedger: 1,
+      events: filterEvents(
+        getEventsResponseFixture,
+        'AAAABQAAAAh0cmFuc2Zlcg==/AAAAAQB6Mcc='
+      )
+    };
 
     setupMock(
       this.axiosMock,
@@ -104,10 +110,13 @@ describe('Server#getEvents', function () {
   });
 
   it('can build mixed filters', function (done) {
-    let result = filterEventsByLedger(
-      filterEvents(getEventsResponseFixture, 'AAAABQAAAAh0cmFuc2Zlcg==/*'),
-      1
-    );
+    let result =  {
+      latestLedger: 1,
+      events: filterEventsByLedger(
+        filterEvents(getEventsResponseFixture, 'AAAABQAAAAh0cmFuc2Zlcg==/*'),
+        1
+      ),
+    };
 
     setupMock(
       this.axiosMock,
@@ -140,10 +149,13 @@ describe('Server#getEvents', function () {
   });
 
   it('can paginate', function (done) {
-    let result = filterEventsByLedger(
-      filterEvents(getEventsResponseFixture, '*/*'),
-      1
-    );
+    let result = {
+      latestLedger: 1,
+      events: filterEventsByLedger(
+        filterEvents(getEventsResponseFixture, '*/*'),
+        1
+      )
+    };
 
     setupMock(
       this.axiosMock,
@@ -203,6 +215,13 @@ function setupMock(axiosMock, params, result) {
       params: params
     })
     .returns(Promise.resolve({ data: { result } }));
+}
+
+function parseEvents(result) {
+  return {
+    ...result,
+    events: result.events.map(SorobanClient.parseEvents),
+  };
 }
 
 let getEventsResponseFixture = [

--- a/test/unit/server/get_events_test.js
+++ b/test/unit/server/get_events_test.js
@@ -37,7 +37,7 @@ describe('Server#getEvents', function () {
   it('can build wildcard filters', function (done) {
     let result = {
       latestLedger: 1,
-      events: filterEvents(getEventsResponseFixture, '*/*'),
+      events: filterEvents(getEventsResponseFixture, '*/*')
     };
 
     setupMock(
@@ -110,12 +110,12 @@ describe('Server#getEvents', function () {
   });
 
   it('can build mixed filters', function (done) {
-    let result =  {
+    let result = {
       latestLedger: 1,
       events: filterEventsByLedger(
         filterEvents(getEventsResponseFixture, 'AAAABQAAAAh0cmFuc2Zlcg==/*'),
         1
-      ),
+      )
     };
 
     setupMock(
@@ -220,7 +220,7 @@ function setupMock(axiosMock, params, result) {
 function parseEvents(result) {
   return {
     ...result,
-    events: result.events.map(SorobanClient.parseRawEvents),
+    events: result.events.map(SorobanClient.parseRawEvents)
   };
 }
 

--- a/test/unit/server/get_events_test.js
+++ b/test/unit/server/get_events_test.js
@@ -220,7 +220,7 @@ function setupMock(axiosMock, params, result) {
 function parseEvents(result) {
   return {
     ...result,
-    events: result.events.map(SorobanClient.parseEvents),
+    events: result.events.map(SorobanClient.parseRawEvents),
   };
 }
 


### PR DESCRIPTION
This makes the following changes to the expected schema for [getEvents endpoint](https://soroban.stellar.org/api/methods/getEvents):

```diff
-   contractId: string;
+   contractId: Contract;
-   topic: string[];
+   topic: xdr.ScVal[];
-   value: {
-     xdr: string;
-   };
+   value: xdr.ScVal;
```

In particular,
 - `events[i].contractId` is now an instance of [`Contract`](https://stellar.github.io/js-soroban-client/Contract.html)
 - `events[i].topic` is now a list of decoded `xdr.ScVal` instances
 - `events[i].value.xdr` is now remapped directly to `events.value`
 - `events[i].value` is a decoded `xdr.ScVal` instance

Related: #128.