### PR TITLE
Automatically parse the error result field in `sendTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 ### Breaking Changes
-* The fields with XDR structures are now automatically decoded for the `Server.getLedgerEntries` response ([#154](https://github.com/stellar/js-soroban-client/pull/154)). Namely,
- - `entries` is now guaranteed to exist, but it may be empty
- - `entries[i].key` is an instance of `xdr.LedgerKey`
- - the `entries[i].xdr` field is now `val`, instead
- - `entries[i].val` is an instance of `xdr.LedgerEntryData`
-* If you want to continue to use the raw RPC response, you can use `Server._getLedgerEntries` method, instead.
+* All endpoints will now automatically decode XDR structures whenever possible. In particular,
+ - For the `Server.getLedgerEntries` response ([#154](https://github.com/stellar/js-soroban-client/pull/154)), we parse:
+   * `entries` is now guaranteed to exist, but it may be empty
+   * `entries[i].key` is an instance of `xdr.LedgerKey`
+   * the `entries[i].xdr` field is now `val`, instead
+   * `entries[i].val` is an instance of `xdr.LedgerEntryData`
+ - For the `Server.sendTransaction` response ([#TODO]()), we parse:
+   * `errorResultXdr` is renamed to `errorResult`
+   * If it's present, it's an instance of `xdr.TransactionResult`
+* If you want to continue to use the raw RPC responses, you can use `Server._getLedgerEntries` and `Server._sendTransaction` methods, instead.
 
 
 ## v1.0.0-beta.2

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,6 +1,23 @@
 import { xdr, SorobanDataBuilder } from 'stellar-base';
 import { SorobanRpc } from './soroban_rpc';
 
+
+export function parseRawSendTransaction(
+  r: SorobanRpc.RawSendTransactionResponse
+): SorobanRpc.SendTransactionResponse {
+  if (!!r.errorResultXdr) {
+    return {
+      ...r,
+      errorResultXdr: xdr.TransactionResult.fromXDR(
+        r.errorResultXdr, 'base64'
+      )
+    };
+  }
+
+  delete r.errorResultXdr;
+  return { ...r } as SorobanRpc.BaseSendTransactionResponse;
+}
+
 export function parseRawLedgerEntries(
   raw: SorobanRpc.RawGetLedgerEntriesResponse
 ): SorobanRpc.GetLedgerEntriesResponse {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -5,16 +5,16 @@ import { SorobanRpc } from './soroban_rpc';
 export function parseRawSendTransaction(
   r: SorobanRpc.RawSendTransactionResponse
 ): SorobanRpc.SendTransactionResponse {
-  if (!!r.errorResultXdr) {
+  const errResult = r.errorResultXdr;
+  delete r.errorResultXdr;
+
+  if (!!errResult) {
     return {
       ...r,
-      errorResult: xdr.TransactionResult.fromXDR(
-        r.errorResultXdr, 'base64'
-      )
+      errorResult: xdr.TransactionResult.fromXDR(errResult, 'base64')
     };
   }
 
-  delete r.errorResultXdr;
   return { ...r } as SorobanRpc.BaseSendTransactionResponse;
 }
 

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -8,7 +8,7 @@ export function parseRawSendTransaction(
   if (!!r.errorResultXdr) {
     return {
       ...r,
-      errorResultXdr: xdr.TransactionResult.fromXDR(
+      errorResult: xdr.TransactionResult.fromXDR(
         r.errorResultXdr, 'base64'
       )
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,11 @@ import { Friendbot } from "./friendbot";
 import * as jsonrpc from "./jsonrpc";
 import { SorobanRpc } from "./soroban_rpc";
 import { assembleTransaction } from "./transaction";
-import { parseRawSimulation, parseRawLedgerEntries } from "./parsers";
+import {
+  parseRawSendTransaction,
+  parseRawSimulation,
+  parseRawLedgerEntries
+} from "./parsers";
 
 export const SUBMIT_TRANSACTION_TIMEOUT = 60 * 1000;
 
@@ -626,11 +630,11 @@ export class Server {
   public async sendTransaction(
     transaction: Transaction | FeeBumpTransaction,
   ): Promise<SorobanRpc.SendTransactionResponse> {
-    return await jsonrpc.post(
+    return jsonrpc.post<SorobanRpc.RawSendTransactionResponse>(
       this.serverURL.toString(),
       "sendTransaction",
       transaction.toXDR(),
-    );
+    ).then(parseRawSendTransaction)
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -630,11 +630,17 @@ export class Server {
   public async sendTransaction(
     transaction: Transaction | FeeBumpTransaction,
   ): Promise<SorobanRpc.SendTransactionResponse> {
-    return jsonrpc.post<SorobanRpc.RawSendTransactionResponse>(
+    return this._sendTransaction(transaction).then(parseRawSendTransaction);
+  }
+
+  public async _sendTransaction(
+    transaction: Transaction | FeeBumpTransaction,
+  ): Promise<SorobanRpc.RawSendTransactionResponse> {
+    return jsonrpc.post(
       this.serverURL.toString(),
       "sendTransaction",
       transaction.toXDR(),
-    ).then(parseRawSendTransaction)
+    );
   }
 
   /**

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -162,7 +162,7 @@ export namespace SorobanRpc {
     | "ERROR";
 
   export interface SendTransactionResponse extends BaseSendTransactionResponse {
-    errorResultXdr?: xdr.TransactionResult;
+    errorResult?: xdr.TransactionResult;
   }
 
   export interface RawSendTransactionResponse extends BaseSendTransactionResponse {

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -161,12 +161,11 @@ export namespace SorobanRpc {
     | "TRY_AGAIN_LATER"
     | "ERROR";
 
-  export interface SendTransactionResponse {
-    status: SendTransactionStatus;
-    hash: string;
-    latestLedger: number;
-    latestLedgerCloseTime: number;
+  export interface SendTransactionResponse extends BaseSendTransactionResponse {
+    errorResultXdr?: xdr.TransactionResult;
+  }
 
+  export interface RawSendTransactionResponse extends BaseSendTransactionResponse {
     /**
      * This is a base64-encoded instance of {@link xdr.TransactionResult}, set
      * only when `status` is `"ERROR"`.
@@ -174,6 +173,13 @@ export namespace SorobanRpc {
      * It contains details on why the network rejected the transaction.
      */
     errorResultXdr?: string;
+  }
+
+  export interface BaseSendTransactionResponse {
+    status: SendTransactionStatus;
+    hash: string;
+    latestLedger: number;
+    latestLedgerCloseTime: number;
   }
 
   export interface SimulateHostFunctionResult {

--- a/test/unit/server/send_transaction_test.js
+++ b/test/unit/server/send_transaction_test.js
@@ -62,7 +62,7 @@ describe('Server#sendTransaction', function () {
       });
   });
 
-  it('encodes the error result', function(done) {
+  it('encodes the error result', function (done) {
     const txResult = new xdr.TransactionResult({
       feeCharged: new xdr.Int64(1),
       result: xdr.TransactionResultResult.txSorobanInvalid(),
@@ -79,11 +79,14 @@ describe('Server#sendTransaction', function () {
       })
       .returns(
         Promise.resolve({
-          data: { id: 1, result: {
-            id: this.hash,
-            status: 'ERROR',
-            errorResultXdr: txResult.toXDR('base64')
-          }}
+          data: {
+            id: 1,
+            result: {
+              id: this.hash,
+              status: 'ERROR',
+              errorResultXdr: txResult.toXDR('base64')
+            }
+          }
         })
       );
 

--- a/test/unit/server/send_transaction_test.js
+++ b/test/unit/server/send_transaction_test.js
@@ -1,3 +1,5 @@
+const { xdr } = SorobanClient;
+
 describe('Server#sendTransaction', function () {
   let keypair = SorobanClient.Keypair.random();
   let account = new SorobanClient.Account(
@@ -59,6 +61,44 @@ describe('Server#sendTransaction', function () {
         done(err);
       });
   });
+
+  it('encodes the error result', function(done) {
+    const txResult = new xdr.TransactionResult({
+      feeCharged: new xdr.Int64(1),
+      result: xdr.TransactionResultResult.txSorobanInvalid(),
+      ext: new xdr.TransactionResultExt(0)
+    });
+
+    this.axiosMock
+      .expects('post')
+      .withArgs(serverUrl, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'sendTransaction',
+        params: [this.blob]
+      })
+      .returns(
+        Promise.resolve({
+          data: { id: 1, result: {
+            id: this.hash,
+            status: 'ERROR',
+            errorResultXdr: txResult.toXDR('base64')
+          }}
+        })
+      );
+
+    this.server
+      .sendTransaction(this.transaction)
+      .then(function (r) {
+        expect(r.errorResult).to.be.instanceOf(xdr.TransactionResult);
+        expect(r.errorResult).to.eql(txResult);
+        expect(r.errorResultXdr).to.be.undefined;
+
+        done();
+      })
+      .catch(done);
+  });
+
   xit('adds metadata - tx was too small and was immediately deleted');
   xit('adds metadata, order immediately fills');
   xit('adds metadata, order is open');


### PR DESCRIPTION
In particular,

```diff
-    errorResultXdr?: string;
+    errorResult?: xdr.TransactionResult;
```

The error result field, if present, will automatically be decoded.
 
Closes #128.