### PR TITLE
Adds a raw `Server._simulateTransaction` to match others

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -269,21 +269,19 @@ export class Server {
   public async getLedgerEntries(
     ...keys: xdr.LedgerKey[]
   ): Promise<SorobanRpc.GetLedgerEntriesResponse> {
-    return this._getLedgerEntries(
-      ...expandRequestIncludeExpirationLedgers(keys)
-    )
-      .then((response) => mergeResponseExpirationLedgers(response, keys))
-      .then(parseRawLedgerEntries);
+    return this._getLedgerEntries(...keys).then(parseRawLedgerEntries);
   }
 
-  public async _getLedgerEntries(
-    ...keys: xdr.LedgerKey[]
-  ): Promise<SorobanRpc.RawGetLedgerEntriesResponse> {
-    return jsonrpc.post(
-      this.serverURL.toString(),
-      'getLedgerEntries',
-      keys.map((k) => k.toXDR('base64'))
-    );
+  public async _getLedgerEntries(...keys: xdr.LedgerKey[]) {
+    return jsonrpc
+      .post<SorobanRpc.RawGetLedgerEntriesResponse>(
+        this.serverURL.toString(),
+        'getLedgerEntries',
+        expandRequestIncludeExpirationLedgers(keys).map((k) =>
+          k.toXDR('base64')
+        )
+      )
+      .then((response) => mergeResponseExpirationLedgers(response, keys));
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -272,7 +272,7 @@ export class Server {
   public async _getLedgerEntries(
     ...keys: xdr.LedgerKey[]
   ): Promise<SorobanRpc.RawGetLedgerEntriesResponse> {
-    return jsonrpc.post<SorobanRpc.RawGetLedgerEntriesResponse>(
+    return jsonrpc.post(
       this.serverURL.toString(),
       "getLedgerEntries",
       keys.map((k) => k.toXDR("base64")),
@@ -345,7 +345,7 @@ export class Server {
   public async _getTransaction(
     hash: string,
   ): Promise<SorobanRpc.RawGetTransactionResponse> {
-    return jsonrpc.post<SorobanRpc.RawGetTransactionResponse>(
+    return jsonrpc.post(
       this.serverURL.toString(),
       "getTransaction",
       hash,
@@ -399,7 +399,7 @@ export class Server {
   public async _getEvents(
     request: Server.GetEventsRequest,
   ): Promise<SorobanRpc.RawGetEventsResponse> {
-    return jsonrpc.postObject<SorobanRpc.RawGetEventsResponse>(
+    return jsonrpc.postObject(
       this.serverURL.toString(),
       "getEvents",
       {
@@ -495,13 +495,17 @@ export class Server {
   public async simulateTransaction(
     transaction: Transaction | FeeBumpTransaction,
   ): Promise<SorobanRpc.SimulateTransactionResponse> {
-    return jsonrpc
-      .post<SorobanRpc.RawSimulateTransactionResponse>(
-        this.serverURL.toString(),
-        "simulateTransaction",
-        transaction.toXDR(),
-      )
-      .then(parseRawSimulation);
+    return this._simulateTransaction(transaction).then(parseRawSimulation);
+  }
+
+  public async _simulateTransaction(
+    transaction: Transaction | FeeBumpTransaction,
+  ): Promise<SorobanRpc.RawSimulateTransactionResponse> {
+    return jsonrpc.post(
+      this.serverURL.toString(),
+      "simulateTransaction",
+      transaction.toXDR(),
+    );
   }
 
   /**


### PR DESCRIPTION
These are useful for debugging in situations where parsing reveals some underlying bug.

It also removes the `json.post<T>` syntax as the `T` is implied by the `Server` method's return value.