### PR TITLE
update the docs to reference expirationLedgerSeq 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A breaking change should be clearly marked in this log.
 ## Unreleased
 
 ## Added
-* Include `expiration` attribute on ledger data entries in `getContractData` and `getLedgerEntries` responses ([#153](https://github.com/stellar/js-soroban-client/pull/153)).
+* Include `expirationLedgerSeq` attribute on ledger data entries in `getContractData` and `getLedgerEntries` responses ([#153](https://github.com/stellar/js-soroban-client/pull/153)).
 
 ### Breaking Changes
 * All endpoints will now automatically decode XDR structures whenever possible. In particular,

--- a/src/server.ts
+++ b/src/server.ts
@@ -171,7 +171,7 @@ export class Server {
    * const key = xdr.ScVal.scvSymbol("counter");
    * server.getContractData(contractId, key, Durability.Temporary).then(data => {
    *   console.log("value:", data.val);
-   *   console.log("expiration:", data.expiration);
+   *   console.log("expirationLedgerSeq:", data.expirationLedgerSeq);
    *   console.log("lastModified:", data.lastModifiedLedgerSeq);
    *   console.log("latestLedger:", data.latestLedger);
    * });
@@ -261,7 +261,7 @@ export class Server {
    *   const ledgerData = response.entries[0];
    *   console.log("key:", ledgerData.key);
    *   console.log("value:", ledgerData.val);
-   *   console.log("expiration:", ledgerData.expiration);
+   *   console.log("expirationLedgerSeq:", ledgerData.expirationLedgerSeq);
    *   console.log("lastModified:", ledgerData.lastModifiedLedgerSeq);
    *   console.log("latestLedger:", response.latestLedger);
    * });


### PR DESCRIPTION
noticed the docs were referring to an older 'expiration' field which was incorrect, it should be `expirationLedgerSeq`