### PR TITLE
Drop expiration workaround in lieu of new TTL in schema

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -49,7 +49,9 @@ export function parseRawLedgerEntries(
         lastModifiedLedgerSeq: rawEntry.lastModifiedLedgerSeq,
         key: xdr.LedgerKey.fromXDR(rawEntry.key, 'base64'),
         val: xdr.LedgerEntryData.fromXDR(rawEntry.xdr, 'base64'),
-        liveUntilLedgerSeq: rawEntry.liveUntilLedgerSeq
+        ...(rawEntry.liveUntilLedgerSeq !== undefined && {
+          liveUntilLedgerSeq: rawEntry.liveUntilLedgerSeq
+        })
       };
     })
   };

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -49,7 +49,7 @@ export function parseRawLedgerEntries(
         lastModifiedLedgerSeq: rawEntry.lastModifiedLedgerSeq,
         key: xdr.LedgerKey.fromXDR(rawEntry.key, 'base64'),
         val: xdr.LedgerEntryData.fromXDR(rawEntry.xdr, 'base64'),
-        expirationLedgerSeq: rawEntry.expirationLedgerSeq
+        liveUntilLedgerSeq: rawEntry.liveUntilLedgerSeq
       };
     })
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,9 +8,7 @@ import {
   FeeBumpTransaction,
   Keypair,
   Transaction,
-  xdr,
-  hash,
-  Operation
+  xdr
 } from 'stellar-base';
 
 import AxiosClient from './axios';

--- a/src/server.ts
+++ b/src/server.ts
@@ -272,12 +272,11 @@ export class Server {
   }
 
   public async _getLedgerEntries(...keys: xdr.LedgerKey[]) {
-    return jsonrpc
-      .post<SorobanRpc.RawGetLedgerEntriesResponse>(
-        this.serverURL.toString(),
-        'getLedgerEntries',
-        keys.map((k) => k.toXDR('base64'))
-      );
+    return jsonrpc.post<SorobanRpc.RawGetLedgerEntriesResponse>(
+      this.serverURL.toString(),
+      'getLedgerEntries',
+      keys.map((k) => k.toXDR('base64'))
+    );
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,8 @@ import {
   Keypair,
   Transaction,
   xdr,
-  hash
+  hash,
+  Operation
 } from 'stellar-base';
 
 import AxiosClient from './axios';
@@ -171,7 +172,7 @@ export class Server {
    * const key = xdr.ScVal.scvSymbol("counter");
    * server.getContractData(contractId, key, Durability.Temporary).then(data => {
    *   console.log("value:", data.val);
-   *   console.log("expirationLedgerSeq:", data.expirationLedgerSeq);
+   *   console.log("liveUntilLedgerSeq:", data.liveUntilLedgerSeq);
    *   console.log("lastModified:", data.lastModifiedLedgerSeq);
    *   console.log("latestLedger:", data.latestLedger);
    * });
@@ -261,7 +262,7 @@ export class Server {
    *   const ledgerData = response.entries[0];
    *   console.log("key:", ledgerData.key);
    *   console.log("value:", ledgerData.val);
-   *   console.log("expirationLedgerSeq:", ledgerData.expirationLedgerSeq);
+   *   console.log("liveUntilLedgerSeq:", ledgerData.liveUntilLedgerSeq);
    *   console.log("lastModified:", ledgerData.lastModifiedLedgerSeq);
    *   console.log("latestLedger:", response.latestLedger);
    * });
@@ -277,11 +278,8 @@ export class Server {
       .post<SorobanRpc.RawGetLedgerEntriesResponse>(
         this.serverURL.toString(),
         'getLedgerEntries',
-        expandRequestIncludeExpirationLedgers(keys).map((k) =>
-          k.toXDR('base64')
-        )
-      )
-      .then((response) => mergeResponseExpirationLedgers(response, keys));
+        keys.map((k) => k.toXDR('base64'))
+      );
   }
 
   /**
@@ -455,7 +453,7 @@ export class Server {
    *
    * @param {Transaction | FeeBumpTransaction} transaction  the transaction to
    *    simulate, which should include exactly one operation (one of
-   *    {@link xdr.InvokeHostFunctionOp}, {@link xdr.BumpFootprintExpirationOp},
+   *    {@link xdr.InvokeHostFunctionOp}, {@link xdr.ExtendFootprintTTLOp},
    *    or {@link xdr.RestoreFootprintOp}). Any provided footprint or auth
    *    information will be ignored.
    *
@@ -526,7 +524,7 @@ export class Server {
    *
    * @param {Transaction | FeeBumpTransaction} transaction  the transaction to
    *    prepare. It should include exactly one operation, which must be one of
-   *    {@link xdr.InvokeHostFunctionOp}, {@link xdr.BumpFootprintExpirationOp},
+   *    {@link xdr.InvokeHostFunctionOp}, {@link xdr.ExtendFootprintTTLOp},
    *    or {@link xdr.RestoreFootprintOp}.
    *
    *    Any provided footprint will be overwritten. However, if your operation
@@ -751,73 +749,4 @@ function findCreatedAccountSequenceInTransactionMeta(
   }
 
   throw new Error('No account created in transaction');
-}
-
-// TODO - remove once rpc updated to
-// append expiration entry per data LK requested onto server-side response
-// https://github.com/stellar/soroban-tools/issues/1010
-function mergeResponseExpirationLedgers(
-  ledgerEntriesResponse: SorobanRpc.RawGetLedgerEntriesResponse,
-  requestedKeys: xdr.LedgerKey[]
-): SorobanRpc.RawGetLedgerEntriesResponse {
-  const requestedKeyXdrs = new Set<String>(
-    requestedKeys.map((requestedKey) => requestedKey.toXDR('base64'))
-  );
-  const expirationKeyToRawEntryResult = new Map<
-    String,
-    SorobanRpc.RawLedgerEntryResult
-  >();
-  (ledgerEntriesResponse.entries ?? []).forEach((rawEntryResult) => {
-    if (!rawEntryResult.key || !rawEntryResult.xdr) {
-      throw new TypeError(
-        `invalid ledger entry: ${JSON.stringify(rawEntryResult)}`
-      );
-    }
-    const parsedKey = xdr.LedgerKey.fromXDR(rawEntryResult.key, 'base64');
-    const isExpirationMeta =
-      parsedKey.switch().value === xdr.LedgerEntryType.ttl().value &&
-      !requestedKeyXdrs.has(rawEntryResult.key);
-    const keyHash = isExpirationMeta
-      ? parsedKey.ttl().keyHash().toString()
-      : hash(parsedKey.toXDR()).toString();
-
-    const rawEntry =
-      expirationKeyToRawEntryResult.get(keyHash) ?? rawEntryResult;
-
-    if (isExpirationMeta) {
-      const expirationLedgerSeq = xdr.LedgerEntryData.fromXDR(
-        rawEntryResult.xdr,
-        'base64'
-      )
-        .ttl()
-        .liveUntilLedgerSeq();
-      expirationKeyToRawEntryResult.set(keyHash, {
-        ...rawEntry,
-        expirationLedgerSeq
-      });
-    } else {
-      expirationKeyToRawEntryResult.set(keyHash, {
-        ...rawEntry,
-        ...rawEntryResult
-      });
-    }
-  });
-
-  ledgerEntriesResponse.entries = [...expirationKeyToRawEntryResult.values()];
-  return ledgerEntriesResponse;
-}
-
-// TODO - remove once rpc updated to
-// include expiration entry on responses for any data LK's requested
-// https://github.com/stellar/soroban-tools/issues/1010
-function expandRequestIncludeExpirationLedgers(
-  keys: xdr.LedgerKey[]
-): xdr.LedgerKey[] {
-  return keys.concat(
-    keys
-      .filter((key) => key.switch().value !== xdr.LedgerEntryType.ttl().value)
-      .map((key) =>
-        xdr.LedgerKey.ttl(new xdr.LedgerKeyTtl({ keyHash: hash(key.toXDR()) }))
-      )
-  );
 }

--- a/src/soroban_rpc.ts
+++ b/src/soroban_rpc.ts
@@ -28,7 +28,7 @@ export namespace SorobanRpc {
     lastModifiedLedgerSeq?: number;
     key: xdr.LedgerKey;
     val: xdr.LedgerEntryData;
-    expirationLedgerSeq?: number;
+    liveUntilLedgerSeq?: number;
   }
 
   export interface RawLedgerEntryResult {
@@ -40,7 +40,7 @@ export namespace SorobanRpc {
     /** optional, a future ledger number upon which this entry will expire
      *  based on https://github.com/stellar/soroban-tools/issues/1010
      */
-    expirationLedgerSeq?: number;
+    liveUntilLedgerSeq?: number;
   }
 
   /** An XDR-parsed version of {@link RawLedgerEntryResult} */

--- a/test/unit/server/get_account_test.js
+++ b/test/unit/server/get_account_test.js
@@ -16,9 +16,6 @@ describe('Server#getAccount', function () {
   const key = xdr.LedgerKey.account(new xdr.LedgerKeyAccount({ accountId }));
   const accountEntry =
     'AAAAAAAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1g3gtpoE608YAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAQAAAAAY9D8iA';
-  const ledgerTtlKey = xdr.LedgerKey.ttl(
-    new xdr.LedgerKeyTtl({ keyHash: hash(key.toXDR()) })
-  );
 
   it('requests the correct method', function (done) {
     this.axiosMock
@@ -27,7 +24,7 @@ describe('Server#getAccount', function () {
         jsonrpc: '2.0',
         id: 1,
         method: 'getLedgerEntries',
-        params: [[key.toXDR('base64'), ledgerTtlKey.toXDR('base64')]]
+        params: [[key.toXDR('base64')]]
       })
       .returns(
         Promise.resolve({
@@ -64,7 +61,7 @@ describe('Server#getAccount', function () {
         jsonrpc: '2.0',
         id: 1,
         method: 'getLedgerEntries',
-        params: [[key.toXDR('base64'), ledgerTtlKey.toXDR('base64')]]
+        params: [[key.toXDR('base64')]]
       })
       .returns(
         Promise.resolve({

--- a/test/unit/server/get_ledger_entries_test.js
+++ b/test/unit/server/get_ledger_entries_test.js
@@ -19,20 +19,12 @@ describe('Server#getLedgerEntries', function () {
       key: ledgerEntry.contractData().key()
     })
   );
-  const ledgerTtlKey = xdr.LedgerKey.ttl(
-    new xdr.LedgerKeyTtl({ keyHash: hash(ledgerKey.toXDR()) })
-  );
   const ledgerTtlEntry = new xdr.TtlEntry({
     keyHash: hash(ledgerKey.toXDR()),
     liveUntilLedgerSeq: 1000
   });
-  const ledgerTtlEntryData = xdr.LedgerEntryData.ttl(ledgerTtlEntry);
-
-  const ledgerEntryXDR = ledgerEntry.toXDR('base64');
   const ledgerKeyXDR = ledgerKey.toXDR('base64');
-  const ledgerTtlKeyXDR = ledgerTtlKey.toXDR('base64');
-  const ledgerTtlEntryXDR = ledgerTtlEntry.toXDR('base64');
-  const ledgerTtlEntryDataXDR = ledgerTtlEntryData.toXDR('base64');
+  const ledgerEntryXDR = ledgerEntry.toXDR('base64');
 
   beforeEach(function () {
     this.server = new SorobanClient.Server(serverUrl);
@@ -65,45 +57,14 @@ describe('Server#getLedgerEntries', function () {
       );
   }
 
-  it('ledger entry found, includes expiration meta', function (done) {
+  it('ledger entry found, includes ttl meta in response', function (done) {
     mockRPC(
       this.axiosMock,
-      [ledgerKeyXDR, ledgerTtlKeyXDR],
+      [ledgerKeyXDR],
       [
         {
-          lastModifiedLedgerSeq: 1,
-          key: ledgerKeyXDR,
-          xdr: ledgerEntryXDR
-        },
-        {
+          liveUntilLedgerSeq: ledgerTtlEntry.liveUntilLedgerSeq(),
           lastModifiedLedgerSeq: 2,
-          key: ledgerTtlKeyXDR,
-          xdr: ledgerTtlEntryDataXDR
-        }
-      ]
-    );
-
-    this.server
-      .getLedgerEntries(ledgerKey)
-      .then((response) => {
-        expect(response.entries).to.have.lengthOf(1);
-        let result = response.entries[0];
-        expect(result.lastModifiedLedgerSeq).to.eql(1);
-        expect(result.key.toXDR('base64')).to.eql(ledgerKeyXDR);
-        expect(result.val.toXDR('base64')).to.eql(ledgerEntryXDR);
-        expect(result.expirationLedgerSeq).to.eql(1000);
-        done();
-      })
-      .catch((err) => done(err));
-  });
-
-  it('ledger entry found, no expiration meta included in response', function (done) {
-    mockRPC(
-      this.axiosMock,
-      [ledgerKeyXDR, ledgerTtlKeyXDR],
-      [
-        {
-          lastModifiedLedgerSeq: 1,
           key: ledgerKeyXDR,
           xdr: ledgerEntryXDR
         }
@@ -112,72 +73,40 @@ describe('Server#getLedgerEntries', function () {
 
     this.server
       .getLedgerEntries(ledgerKey)
-      .then((response) => {
-        expect(response.entries).to.have.lengthOf(1);
-        let result = response.entries[0];
-        expect(result.lastModifiedLedgerSeq).to.eql(1);
-        expect(result.key.toXDR('base64')).to.eql(ledgerKeyXDR);
-        expect(result.val.toXDR('base64')).to.eql(ledgerEntryXDR);
-        expect(result.expirationLedgerSeq).to.be.undefined;
-        done();
-      })
-      .catch((err) => done(err));
-  });
-
-  it('ledger entry found, includes expiration meta from any order in response', function (done) {
-    mockRPC(
-      this.axiosMock,
-      [ledgerKeyXDR, ledgerTtlKeyXDR],
-      [
-        {
-          lastModifiedLedgerSeq: 2,
-          key: ledgerTtlKeyXDR,
-          xdr: ledgerTtlEntryDataXDR
-        },
-        {
-          lastModifiedLedgerSeq: 1,
-          key: ledgerKeyXDR,
-          xdr: ledgerEntryXDR
-        }
-      ]
-    );
-
-    this.server
-      .getLedgerEntries(ledgerKey)
-      .then((response) => {
-        expect(response.entries).to.have.lengthOf(1);
-        let result = response.entries[0];
-        expect(result.lastModifiedLedgerSeq).to.eql(1);
-        expect(result.key.toXDR('base64')).to.eql(ledgerKeyXDR);
-        expect(result.val.toXDR('base64')).to.eql(ledgerEntryXDR);
-        expect(result.expirationLedgerSeq).to.eql(1000);
-        done();
-      })
-      .catch((err) => done(err));
-  });
-
-  it('ledger expiration key is requested by caller, no expiration meta needed on response', function (done) {
-    mockRPC(
-      this.axiosMock,
-      [ledgerTtlKeyXDR],
-      [
-        {
-          lastModifiedLedgerSeq: 2,
-          key: ledgerTtlKeyXDR,
-          xdr: ledgerTtlEntryDataXDR
-        }
-      ]
-    );
-
-    this.server
-      .getLedgerEntries(ledgerTtlKey)
       .then((response) => {
         expect(response.entries).to.have.lengthOf(1);
         let result = response.entries[0];
         expect(result.lastModifiedLedgerSeq).to.eql(2);
-        expect(result.key.toXDR('base64')).to.eql(ledgerTtlKeyXDR);
-        expect(result.val.toXDR('base64')).to.eql(ledgerTtlEntryDataXDR);
-        expect(result.expirationLedgerSeq).to.be.undefined;
+        expect(result.key.toXDR('base64')).to.eql(ledgerKeyXDR);
+        expect(result.val.toXDR('base64')).to.eql(ledgerEntryXDR);
+        expect(result.liveUntilLedgerSeq).to.eql(1000);
+        done();
+      })
+      .catch((err) => done(err));
+  });
+
+  it('ledger entry found, no ttl in response', function (done) {
+    mockRPC(
+      this.axiosMock,
+      [ledgerKeyXDR],
+      [
+        {
+          lastModifiedLedgerSeq: 2,
+          key: ledgerKeyXDR,
+          xdr: ledgerEntryXDR
+        }
+      ]
+    );
+
+    this.server
+      .getLedgerEntries(ledgerKey)
+      .then((response) => {
+        expect(response.entries).to.have.lengthOf(1);
+        let result = response.entries[0];
+        expect(result.lastModifiedLedgerSeq).to.eql(2);
+        expect(result.key.toXDR('base64')).to.eql(ledgerKeyXDR);
+        expect(result.val.toXDR('base64')).to.eql(ledgerEntryXDR);
+        expect(result.liveUntilLedgerSeq).to.be.undefined;
         done();
       })
       .catch((err) => done(err));
@@ -187,7 +116,7 @@ describe('Server#getLedgerEntries', function () {
     // these are simulating invalid json, missing `xdr` and `key`
     mockRPC(
       this.axiosMock,
-      [ledgerKeyXDR, ledgerTtlKeyXDR],
+      [ledgerKeyXDR],
       [
         {
           lastModifiedLedgerSeq: 2

--- a/test/unit/server/request_airdrop_test.js
+++ b/test/unit/server/request_airdrop_test.js
@@ -125,7 +125,7 @@ describe('Server#requestAirdrop', function () {
         jsonrpc: '2.0',
         id: 1,
         method: 'getLedgerEntries',
-        params: [[accountKey.toXDR('base64'), ledgerTtlKey.toXDR('base64')]]
+        params: [[accountKey.toXDR('base64')]]
       })
       .returns(
         Promise.resolve({


### PR DESCRIPTION
The response schema now includes `liveUntilLedgerSeq` by default, so we no longer need to inject the expiration ledgers into requests and parse that information.

(Note that this is targeting the `stable` branch.)

Closes this part of https://github.com/stellar/js-stellar-sdk/issues/869.